### PR TITLE
Refactor CDR reader and IDL loading

### DIFF
--- a/cdr_reader.py
+++ b/cdr_reader.py
@@ -80,7 +80,7 @@ class CdrReader:
             "int16": "h",
             "int32": "i",
             "uint32": "I",
-            "int16": "h",
+            # "int16": "h",  # Removed duplicate
             "uint16": "H",
             "int64": "q",
             "uint64": "Q",

--- a/cdr_reader.py
+++ b/cdr_reader.py
@@ -81,7 +81,6 @@ class CdrReader:
             "int32": "i",
             "uint32": "I",
             # "int16": "h",  # Removed duplicate
-            "uint16": "H",
             "int64": "q",
             "uint64": "Q",
             "float32": "f",

--- a/cdr_reader.py
+++ b/cdr_reader.py
@@ -54,7 +54,7 @@ class CdrReader:
         return result
 
     def _read_array(self, field):
-        # シーケンスの長さは UInt32 prefix 付き
+        # Sequence length is prefixed with UInt32
         length = self._read_primitive("uint32")
         items = []
         for _ in range(length):

--- a/cdr_reader.py
+++ b/cdr_reader.py
@@ -1,0 +1,106 @@
+import io
+import struct
+
+
+class Field:
+    def __init__(self, name, type, isComplex, **kwargs):
+        self.name = name
+        self.type = type
+        self.is_complex = isComplex
+        self.is_array = kwargs.get("isArray", False)
+        self.array_upper_bound = kwargs.get("arrayUpperBound")
+        self.default_value = kwargs.get("defaultValue")
+        self.upper_bound = kwargs.get("upperBound")
+        self.enum_type = kwargs.get("enumType")
+        if self.enum_type:
+            self.enum_type = self.enum_type.replace("::", "/")
+
+
+class MessageType:
+    def __init__(self, name, definitions):
+        self.name = name
+        self.fields = [Field(**field) for field in definitions]
+
+
+class CdrReader:
+    def __init__(self, type_map, enum_map=None):
+        self.types = type_map
+        self.enums = enum_map
+        self.stream = None
+
+    def read(self, typename, data: bytes):
+        self.stream = io.BytesIO(data)
+        self._read_primitive("uint32")  # Skip the CDR header
+        return self._read_message(self.types[typename])
+
+    def _align(self, size: int, base: int = 4):
+        relative_offset = self.stream.tell() - base
+        padding = (size - (relative_offset % size)) % size
+        self.stream.seek(padding, io.SEEK_CUR)
+
+    def _read_message(self, msg_type: 'MessageType'):
+        result = {}
+        for field in msg_type.fields:
+            print(f"Reading field: {field.name} of type {field.type}")
+            if field.name == "status":
+                print(f"Reading status field: {field.name} of type {field.type}")
+                print(f"Enum type: {field.enum_type}")
+            if field.is_array:
+                result[field.name] = self._read_array(field)
+            elif field.is_complex:
+                result[field.name] = self._read_message(self.types[field.type])
+            else:
+                result[field.name] = self._read_primitive(field.type, field.enum_type)
+        return result
+
+    def _read_array(self, field):
+        # シーケンスの長さは UInt32 prefix 付き
+        length = self._read_primitive("uint32")
+        items = []
+        for _ in range(length):
+            if field.is_complex:
+                items.append(self._read_message(self.types[field.type]))
+            else:
+                items.append(self._read_primitive(field.type, field.enum_type))
+        return items
+
+    def _read_primitive(self, type_name, enum_type=None):
+        if enum_type:
+            print(f"Reading enum type: {enum_type}")
+        if type_name in ("uint32", "int32", "float32"):
+            self._align(4)
+        elif type_name in ("uint64", "int64", "float64"):
+            self._align(8)
+        elif type_name in ("uint16", "int16"):
+            self._align(2)
+        fmt = {
+            "uint8": "B",
+            "int8": "b",
+            "uint16": "H",
+            "int16": "h",
+            "int32": "i",
+            "uint32": "I",
+            "int16": "h",
+            "uint16": "H",
+            "int64": "q",
+            "uint64": "Q",
+            "float32": "f",
+            "float64": "d",
+            "bool": "?",
+        }.get(type_name)
+        if enum_type:
+            print(f"Reading enum type: {enum_type}")
+            if enum_type not in self.enums:
+                raise ValueError(f"Unknown enum type: {enum_type}")
+            enum_lookup = self.enums[enum_type]
+            value = self._read_primitive("int32")
+            return enum_lookup.get(value, f"Unknown enum value: {value}")
+
+        if fmt:
+            return struct.unpack("<" + fmt, self.stream.read(struct.calcsize(fmt)))[0]
+        elif type_name == "string":
+            length = self._read_primitive("uint32")
+            bytes_ = self.stream.read(length)
+            return bytes_[:-1].decode("utf-8")
+        else:
+            raise ValueError(f"Unknown primitive type: {type_name}")

--- a/idl_loader.py
+++ b/idl_loader.py
@@ -1,0 +1,36 @@
+import json
+from typing import Dict, Tuple
+
+from cdr_reader import MessageType
+
+
+def load_idl(path: str) -> Tuple[Dict[int, Dict[str, MessageType]], Dict[int, Dict[str, dict]]]:
+    """Load type definitions and enums from a JSON file.
+
+    Returns two dictionaries indexed by schema ID: a map of message types
+    and a map of enum lookups.
+    """
+    with open(path, "r") as f:
+        type_definitions = json.load(f)
+
+    id_to_type_map: Dict[int, Dict[str, MessageType]] = {}
+    id_to_enum_map: Dict[int, Dict[str, dict]] = {}
+
+    for i, schema in type_definitions.items():
+        schema_id = int(i)
+        type_map: Dict[str, MessageType] = {}
+        enum_map: Dict[str, dict] = {}
+        for type_def in schema:
+            type_map[type_def["name"]] = MessageType(
+                type_def["name"], type_def["definitions"]
+            )
+            enum_candidates = [
+                f for f in type_def.get("definitions", []) if f.get("isConstant")
+            ]
+            if enum_candidates:
+                enum_lookup = {f["value"]: f["name"] for f in enum_candidates}
+                enum_map[type_def["name"]] = enum_lookup
+        id_to_type_map[schema_id] = type_map
+        id_to_enum_map[schema_id] = enum_map
+
+    return id_to_type_map, id_to_enum_map

--- a/idl_loader.py
+++ b/idl_loader.py
@@ -1,20 +1,28 @@
 import json
-from typing import Dict, Tuple
+from dataclasses import dataclass
+from typing import Dict
 
 from cdr_reader import MessageType
 
 
-def load_idl(path: str) -> Tuple[Dict[int, Dict[str, MessageType]], Dict[int, Dict[str, dict]]]:
+@dataclass
+class SchemaInfo:
+    """Container for message types and enum lookups for a schema."""
+
+    type_map: Dict[str, MessageType]
+    enum_map: Dict[str, dict]
+
+
+def load_idl(path: str) -> Dict[int, SchemaInfo]:
     """Load type definitions and enums from a JSON file.
 
-    Returns two dictionaries indexed by schema ID: a map of message types
-    and a map of enum lookups.
+    Returns a dictionary indexed by schema ID containing a ``SchemaInfo``
+    instance with message type and enum maps.
     """
     with open(path, "r") as f:
         type_definitions = json.load(f)
 
-    id_to_type_map: Dict[int, Dict[str, MessageType]] = {}
-    id_to_enum_map: Dict[int, Dict[str, dict]] = {}
+    id_to_schema: Dict[int, SchemaInfo] = {}
 
     for i, schema in type_definitions.items():
         schema_id = int(i)
@@ -30,7 +38,6 @@ def load_idl(path: str) -> Tuple[Dict[int, Dict[str, MessageType]], Dict[int, Di
             if enum_candidates:
                 enum_lookup = {f["value"]: f["name"] for f in enum_candidates}
                 enum_map[type_def["name"]] = enum_lookup
-        id_to_type_map[schema_id] = type_map
-        id_to_enum_map[schema_id] = enum_map
+        id_to_schema[schema_id] = SchemaInfo(type_map, enum_map)
 
-    return id_to_type_map, id_to_enum_map
+    return id_to_schema

--- a/ros2_mcap_reader.py
+++ b/ros2_mcap_reader.py
@@ -1,117 +1,13 @@
-import io
-import struct
+import json
+from argparse import ArgumentParser
 
 from mcap.reader import make_reader
 
-
-class Field:
-    def __init__(self, name, type, isComplex, **kwargs):
-        self.name = name
-        self.type = type
-        self.is_complex = isComplex
-        self.is_array = kwargs.get("isArray", False)
-        self.array_upper_bound = kwargs.get("arrayUpperBound")
-        self.default_value = kwargs.get("defaultValue")
-        self.upper_bound = kwargs.get("upperBound")
-        self.enum_type = kwargs.get("enumType")
-        if self.enum_type:
-            self.enum_type = self.enum_type.replace("::", "/")
-
-
-class MessageType:
-    def __init__(self, name, definitions):
-        self.name = name
-        self.fields = [Field(**field) for field in definitions]
-
-
-class CdrReader:
-    def __init__(self, type_map, enum_map=None):
-        self.types = type_map
-        self.enums = enum_map
-        self.stream = None
-
-    def read(self, typename, data: bytes):
-        self.stream = io.BytesIO(data)
-        self._read_primitive("uint32")  # Skip the CDR header
-        return self._read_message(self.types[typename])
-
-    def _align(self, size: int, base: int = 4):
-        relative_offset = self.stream.tell() - base
-        padding = (size - (relative_offset % size)) % size
-        self.stream.seek(padding, io.SEEK_CUR)
-
-    def _read_message(self, msg_type: MessageType):
-        result = {}
-        for field in msg_type.fields:
-            print(f"Reading field: {field.name} of type {field.type}")
-            if field.name == "status":
-                print(f"Reading status field: {field.name} of type {field.type}")
-                print(f"Enum type: {field.enum_type}")
-            if field.is_array:
-                result[field.name] = self._read_array(field)
-            elif field.is_complex:
-                result[field.name] = self._read_message(self.types[field.type])
-            else:
-                result[field.name] = self._read_primitive(field.type, field.enum_type)
-        return result
-
-    def _read_array(self, field):
-        # シーケンスの長さは UInt32 prefix 付き
-        length = self._read_primitive("uint32")
-        items = []
-        for _ in range(length):
-            if field.is_complex:
-                items.append(self._read_message(self.types[field.type]))
-            else:
-                items.append(self._read_primitive(field.type, field.enum_type))
-        return items
-
-    def _read_primitive(self, type_name, enum_type=None):
-        if enum_type:
-            print(f"Reading enum type: {enum_type}")
-        if type_name in ("uint32", "int32", "float32"):
-            self._align(4)
-        elif type_name in ("uint64", "int64", "float64"):
-            self._align(8)
-        elif type_name in ("uint16", "int16"):
-            self._align(2)
-        fmt = {
-            "uint8": "B",
-            "int8": "b",
-            "uint16": "H",
-            "int16": "h",
-            "int32": "i",
-            "uint32": "I",
-            "int16": "h",
-            "uint16": "H",
-            "int64": "q",
-            "uint64": "Q",
-            "float32": "f",
-            "float64": "d",
-            "bool": "?",
-        }.get(type_name)
-        if enum_type:
-            print(f"Reading enum type: {enum_type}")
-            if enum_type not in self.enums:
-                raise ValueError(f"Unknown enum type: {enum_type}")
-            enum_lookup = self.enums[enum_type]
-            value = self._read_primitive("int32")
-            return enum_lookup.get(value, f"Unknown enum value: {value}")
-
-        if fmt:
-            return struct.unpack("<" + fmt, self.stream.read(struct.calcsize(fmt)))[0]
-        elif type_name == "string":
-            length = self._read_primitive("uint32")
-            bytes_ = self.stream.read(length)
-            return bytes_[:-1].decode("utf-8")
-        else:
-            raise ValueError(f"Unknown primitive type: {type_name}")
+from cdr_reader import CdrReader
+from idl_loader import load_idl
 
 
 if __name__ == "__main__":
-    import json
-    from argparse import ArgumentParser
-
     parser = ArgumentParser(description="Read CDR messages from MCAP files.")
     parser.add_argument(
         "--type-definitions",
@@ -127,30 +23,13 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    with open(args.type_definitions, "r") as f:
-        type_definitions = json.load(f)
+    id_to_type_map, id_to_enum_map = load_idl(args.type_definitions)
+    id_to_cdr_reader = {
+        schema_id: CdrReader(type_map, id_to_enum_map.get(schema_id))
+        for schema_id, type_map in id_to_type_map.items()
+    }
 
-    id_to_cdr_reader = {}
-    for i, schema in type_definitions.items():
-        type_map = {}
-        for type_def in schema:
-            type_map[type_def["name"]] = MessageType(
-                type_def["name"], type_def["definitions"]
-            )
-
-        enum_map = {}  # str -> dict[int -> str]
-        for type_def in schema:
-            enum_candidates = [
-                f for f in type_def.get("definitions", []) if f.get("isConstant")
-            ]
-            if enum_candidates:
-                enum_lookup = {f["value"]: f["name"] for f in enum_candidates}
-                enum_map[type_def["name"]] = enum_lookup
-
-        id_to_cdr_reader[int(i)] = CdrReader(type_map, enum_map)
-
-    file_path = args.mcap_file
-    with open(file_path, "rb") as f:
+    with open(args.mcap_file, "rb") as f:
         reader = make_reader(f)
         for topic, schema, message in reader.iter_messages():
             print(f"Topic: {topic}, Schema ID: {schema.schema_id}")

--- a/ros2_mcap_reader.py
+++ b/ros2_mcap_reader.py
@@ -23,10 +23,10 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    id_to_type_map, id_to_enum_map = load_idl(args.type_definitions)
+    schemas = load_idl(args.type_definitions)
     id_to_cdr_reader = {
-        schema_id: CdrReader(type_map, id_to_enum_map.get(schema_id))
-        for schema_id, type_map in id_to_type_map.items()
+        schema_id: CdrReader(info.type_map, info.enum_map)
+        for schema_id, info in schemas.items()
     }
 
     with open(args.mcap_file, "rb") as f:


### PR DESCRIPTION
## Summary
- move Field, MessageType, and CdrReader into new `cdr_reader` module
- add `idl_loader` to build message and enum maps from type definition JSON
- slim down `ros2_mcap_reader` to CLI that uses the new modules

## Testing
- `python -m py_compile ros2_mcap_reader.py cdr_reader.py idl_loader.py`
- `python ros2_mcap_reader.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688eade37d8c833095fc70fe2d076bde