### PR TITLE
Add basic test and CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,20 @@
+name: Python tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 
 .venv
+__pycache__/

--- a/tests/test_idl_loader.py
+++ b/tests/test_idl_loader.py
@@ -1,0 +1,37 @@
+import json
+import sys
+from pathlib import Path
+
+# Ensure the package can be imported without installation
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mcap_schema_cli.idl_loader import load_idl
+
+def test_load_idl(tmp_path):
+    data = {
+        "1": [
+            {
+                "name": "Foo",
+                "definitions": [
+                    {"name": "bar", "type": "string", "isComplex": False},
+                    {
+                        "name": "BAZ",
+                        "type": "int32",
+                        "isComplex": False,
+                        "isConstant": True,
+                        "value": 0,
+                    },
+                ],
+            }
+        ]
+    }
+    json_path = tmp_path / "types.json"
+    json_path.write_text(json.dumps(data))
+    schemas = load_idl(str(json_path))
+    assert 1 in schemas
+    info = schemas[1]
+    assert "Foo" in info.type_map
+    assert "Foo" in info.enum_map
+    assert info.enum_map["Foo"][0] == "BAZ"
+    assert info.type_map["Foo"].name == "Foo"
+


### PR DESCRIPTION
## Summary
- add a basic unit test for `load_idl`
- run tests in GitHub Actions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebeeb3c3c8330ad23801ed3402d7b