### PR TITLE
Add CLI schema extraction test and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check
+      - run: npm run build
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   },
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "build": "tsc",
     "dev": "tsc && node dist/index.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
-    "format": "prettier --write \"src/**/*.{ts,tsx}\""
+    "format": "prettier --write \"src/**/*.{ts,tsx}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx}\""
   },
   "keywords": [],
   "author": "",

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm, open } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { McapWriter } from "@mcap/core";
+import { FileHandleWritable } from "@mcap/nodejs";
+import { promisify } from "node:util";
+import { execFile } from "node:child_process";
+
+const execFileAsync = promisify(execFile);
+
+const encoder = new TextEncoder();
+
+test("CLI outputs parsed schemas", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "mcap-schema-cli-"));
+  const mcapPath = join(dir, "test.mcap");
+  const handle = await open(mcapPath, "w");
+  const writer = new McapWriter({
+    writable: new FileHandleWritable(handle),
+    useSummaryOffsets: true,
+    useMessageIndex: true,
+  });
+
+  try {
+    await writer.start({ profile: "", library: "test" });
+    const schemaId = await writer.registerSchema({
+      name: "string",
+      encoding: "ros2msg",
+      data: encoder.encode("string data"),
+    });
+    const channelId = await writer.registerChannel({
+      schemaId,
+      topic: "/test",
+      messageEncoding: "json",
+      metadata: new Map(),
+    });
+    await writer.addMessage({
+      channelId,
+      sequence: 0,
+      logTime: 0n,
+      publishTime: 0n,
+      data: encoder.encode("hello"),
+    });
+    await writer.end();
+    await handle.close();
+
+    // Build the CLI and run it against the generated MCAP
+    await execFileAsync("npm", ["run", "build"]);
+    const { stdout } = await execFileAsync("node", ["dist/index.js", mcapPath], {
+      encoding: "utf8",
+    });
+
+    const output = JSON.parse(stdout);
+    const defs = output[String(schemaId)];
+    assert.ok(Array.isArray(defs));
+    assert.equal(defs[0].name, "string");
+    assert.equal(defs[0].definitions[0].name, "data");
+    assert.equal(defs[0].definitions[0].type, "string");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noImplicitAny": true
   },
   "include": [
-    "src/*.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- add CLI integration test covering schema extraction
- compile tests via tsconfig and invoke `node --test`
- run linter, formatter, build, and tests in GitHub Actions

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ebf210de88330b7a6bbe9127b100e