### PR TITLE
Add Python formatting and linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,7 +14,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest
+          pip install -r requirements-dev.txt
+      - name: Check formatting
+        run: |
+          black --check mcap_schema_cli tests
+          isort --check-only mcap_schema_cli tests
+      - name: Lint
+        run: flake8 mcap_schema_cli tests
       - name: Run tests
         run: pytest

--- a/mcap_schema_cli/__init__.py
+++ b/mcap_schema_cli/__init__.py
@@ -1,4 +1,4 @@
-from .cdr_reader import Field, MessageType, CdrReader
+from .cdr_reader import CdrReader, Field, MessageType
 from .idl_loader import SchemaInfo, load_idl
 
 __all__ = [

--- a/mcap_schema_cli/cdr_reader.py
+++ b/mcap_schema_cli/cdr_reader.py
@@ -38,7 +38,7 @@ class CdrReader:
         padding = (size - (relative_offset % size)) % size
         self.stream.seek(padding, io.SEEK_CUR)
 
-    def _read_message(self, msg_type: 'MessageType'):
+    def _read_message(self, msg_type: "MessageType"):
         result = {}
         for field in msg_type.fields:
             print(f"Reading field: {field.name} of type {field.type}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+black
+flake8
+isort
+pytest

--- a/tests/test_idl_loader.py
+++ b/tests/test_idl_loader.py
@@ -7,6 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from mcap_schema_cli.idl_loader import load_idl
 
+
 def test_load_idl(tmp_path):
     data = {
         "1": [
@@ -34,4 +35,3 @@ def test_load_idl(tmp_path):
     assert "Foo" in info.enum_map
     assert info.enum_map["Foo"][0] == "BAZ"
     assert info.type_map["Foo"].name == "Foo"
-

--- a/tests/test_idl_loader.py
+++ b/tests/test_idl_loader.py
@@ -2,10 +2,9 @@ import json
 import sys
 from pathlib import Path
 
-# Ensure the package can be imported without installation
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from mcap_schema_cli.idl_loader import load_idl
+from mcap_schema_cli.idl_loader import load_idl  # noqa: E402
 
 
 def test_load_idl(tmp_path):


### PR DESCRIPTION
## Summary
- add development requirements with black, flake8, isort, and pytest
- configure formatting and linting tools
- enforce formatting, lint, and test steps in CI workflow

## Testing
- `black --check mcap_schema_cli tests`
- `isort --check-only mcap_schema_cli tests`
- `flake8 mcap_schema_cli tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec19d3d488330acd530a1f8e3c840