### PR TITLE
Fix enum parsing for non-int32 types

### DIFF
--- a/mcap_schema_cli/cdr_reader.py
+++ b/mcap_schema_cli/cdr_reader.py
@@ -41,10 +41,6 @@ class CdrReader:
     def _read_message(self, msg_type: "MessageType"):
         result = {}
         for field in msg_type.fields:
-            print(f"Reading field: {field.name} of type {field.type}")
-            if field.name == "status":
-                print(f"Reading status field: {field.name} of type {field.type}")
-                print(f"Enum type: {field.enum_type}")
             if field.is_array:
                 result[field.name] = self._read_array(field)
             elif field.is_complex:
@@ -65,14 +61,13 @@ class CdrReader:
         return items
 
     def _read_primitive(self, type_name, enum_type=None):
-        if enum_type:
-            print(f"Reading enum type: {enum_type}")
         if type_name in ("uint32", "int32", "float32"):
             self._align(4)
         elif type_name in ("uint64", "int64", "float64"):
             self._align(8)
         elif type_name in ("uint16", "int16"):
             self._align(2)
+
         fmt = {
             "uint8": "B",
             "int8": "b",
@@ -80,26 +75,26 @@ class CdrReader:
             "int16": "h",
             "int32": "i",
             "uint32": "I",
-            # "int16": "h",  # Removed duplicate
             "int64": "q",
             "uint64": "Q",
             "float32": "f",
             "float64": "d",
             "bool": "?",
         }.get(type_name)
-        if enum_type:
-            print(f"Reading enum type: {enum_type}")
-            if enum_type not in self.enums:
-                raise ValueError(f"Unknown enum type: {enum_type}")
-            enum_lookup = self.enums[enum_type]
-            value = self._read_primitive("int32")
-            return enum_lookup.get(value, f"Unknown enum value: {value}")
 
         if fmt:
-            return struct.unpack("<" + fmt, self.stream.read(struct.calcsize(fmt)))[0]
+            value = struct.unpack("<" + fmt, self.stream.read(struct.calcsize(fmt)))[0]
         elif type_name == "string":
             length = self._read_primitive("uint32")
             bytes_ = self.stream.read(length)
-            return bytes_[:-1].decode("utf-8")
+            value = bytes_[:-1].decode("utf-8")
         else:
             raise ValueError(f"Unknown primitive type: {type_name}")
+
+        if enum_type:
+            if enum_type not in self.enums:
+                raise ValueError(f"Unknown enum type: {enum_type}")
+            enum_lookup = self.enums[enum_type]
+            return enum_lookup.get(value, f"Unknown enum value: {value}")
+
+        return value

--- a/tests/test_cdr_reader.py
+++ b/tests/test_cdr_reader.py
@@ -43,4 +43,3 @@ def test_enum_with_uint8():
     reader = CdrReader(type_map, enum_map)
     data = b"\x00\x00\x00\x00" + b"\x02"
     assert reader.read("Msg", data) == {"status": "OK"}
-

--- a/tests/test_cdr_reader.py
+++ b/tests/test_cdr_reader.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mcap_schema_cli.cdr_reader import CdrReader, MessageType  # noqa: E402
+
+
+def test_enum_with_uint8():
+    type_map = {
+        "Status": MessageType(
+            "Status",
+            [
+                {
+                    "name": "UNKNOWN",
+                    "type": "uint8",
+                    "isComplex": False,
+                    "isConstant": True,
+                    "value": 0,
+                },
+                {
+                    "name": "OK",
+                    "type": "uint8",
+                    "isComplex": False,
+                    "isConstant": True,
+                    "value": 2,
+                },
+            ],
+        ),
+        "Msg": MessageType(
+            "Msg",
+            [
+                {
+                    "name": "status",
+                    "type": "uint8",
+                    "isComplex": False,
+                    "enumType": "Status",
+                }
+            ],
+        ),
+    }
+    enum_map = {"Status": {0: "UNKNOWN", 2: "OK"}}
+    reader = CdrReader(type_map, enum_map)
+    data = b"\x00\x00\x00\x00" + b"\x02"
+    assert reader.read("Msg", data) == {"status": "OK"}
+


### PR DESCRIPTION
## Summary
- fix CDR enum parsing to use the field's actual primitive type
- add regression test for uint8 enums

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec5797fac833089f80dcaaec51411