### PR TITLE
Support ros2idl encoding in tests

### DIFF
--- a/tests/generate_mcap.js
+++ b/tests/generate_mcap.js
@@ -1,0 +1,52 @@
+import { open } from "node:fs/promises";
+import { McapWriter } from "@mcap/core";
+import { FileHandleWritable } from "@mcap/nodejs";
+
+const encoder = new TextEncoder();
+
+const [, , mcapPath, encoding = "ros2msg"] = process.argv;
+
+async function main() {
+  const handle = await open(mcapPath, "w");
+  const writer = new McapWriter({
+    writable: new FileHandleWritable(handle),
+    useSummaryOffsets: true,
+    useMessageIndex: true,
+  });
+
+  try {
+    await writer.start({ profile: "", library: "test" });
+    const schemaData =
+      encoding === "ros2idl"
+        ? encoder.encode("struct Example { string data; };")
+        : encoder.encode("string data");
+    const schemaId = await writer.registerSchema({
+      name: "Example",
+      encoding,
+      data: schemaData,
+    });
+    const channelId = await writer.registerChannel({
+      schemaId,
+      topic: "/test",
+      messageEncoding: "cdr",
+      metadata: new Map(),
+    });
+    const messageData = Buffer.concat([
+      Buffer.from([0, 0, 0, 0]),
+      Buffer.from([6, 0, 0, 0]),
+      Buffer.from("hello\0"),
+    ]);
+    await writer.addMessage({
+      channelId,
+      sequence: 0,
+      logTime: 0n,
+      publishTime: 0n,
+      data: messageData,
+    });
+    await writer.end();
+  } finally {
+    await handle.close();
+  }
+}
+
+await main();

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from mcap.reader import make_reader
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mcap_schema_cli.cdr_reader import CdrReader  # noqa: E402
+from mcap_schema_cli.idl_loader import load_idl  # noqa: E402
+
+
+@pytest.mark.parametrize("encoding", ["ros2msg", "ros2idl"])
+def test_end_to_end(tmp_path: Path, encoding: str) -> None:
+    mcap_path = tmp_path / "test.mcap"
+    subprocess.run(
+        ["node", "tests/generate_mcap.js", str(mcap_path), encoding],
+        check=True,
+    )
+
+    json_path = tmp_path / "types.json"
+    subprocess.run(
+        ["node", "dist/index.js", str(mcap_path), "-o", str(json_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    schemas = load_idl(str(json_path))
+
+    with open(mcap_path, "rb") as f:
+        reader = make_reader(f)
+        for schema, channel, message in reader.iter_messages():
+            info = schemas[schema.id]
+            cdr_reader = CdrReader(info.type_map, info.enum_map)
+            decoded = cdr_reader.read(schema.name, message.data)
+            assert decoded["data"] == "hello"


### PR DESCRIPTION
## Summary
- add generator script that writes MCAP files using either ros2msg or ros2idl schemas
- extend end-to-end test to validate both ros2msg and ros2idl encodings

## Testing
- `npm run build`
- `pytest tests/test_end_to_end.py`

------
https://chatgpt.com/codex/tasks/task_e_688ed0a6ac5c83308698405cd1a31b9b