### PR TITLE
Enable one-step MCAP parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ pip install -r requirements.txt
 ## Usage
 
 ```bash
+python3 -m mcap_schema_cli --mcap-file sample.mcap
+```
+
+This command automatically invokes the Node `mcap-schema-cli` tool to extract
+type definitions before decoding messages. If you already have type definitions
+saved, you can provide them explicitly:
+
+```bash
 mcap-schema-cli sample.mcap -o schemas.json
 python3 -m mcap_schema_cli --type-definitions schemas.json --mcap-file sample.mcap
 ```

--- a/mcap_schema_cli/cli.py
+++ b/mcap_schema_cli/cli.py
@@ -1,6 +1,9 @@
 """Command-line interface for reading CDR messages from MCAP files."""
 
 import json
+import os
+import subprocess
+import tempfile
 from argparse import ArgumentParser
 
 from mcap.reader import make_reader
@@ -15,8 +18,11 @@ def main() -> None:
     parser.add_argument(
         "--type-definitions",
         type=str,
-        required=True,
-        help="Path to the JSON file containing type definitions.",
+        required=False,
+        help=(
+            "Path to the JSON file containing type definitions. "
+            "If omitted, they will be generated using the Node `mcap-schema-cli` tool."
+        ),
     )
     parser.add_argument(
         "--mcap-file",
@@ -26,11 +32,25 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    schemas = load_idl(args.type_definitions)
+    type_defs_path = args.type_definitions
+    cleanup = False
+    if type_defs_path is None:
+        cleanup = True
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as tmp:
+            type_defs_path = tmp.name
+        subprocess.run(
+            ["mcap-schema-cli", args.mcap_file, "-o", type_defs_path],
+            check=True,
+        )
+
+    schemas = load_idl(type_defs_path)
     id_to_cdr_reader = {
         schema_id: CdrReader(info.type_map, info.enum_map)
         for schema_id, info in schemas.items()
     }
+
+    if cleanup:
+        os.unlink(type_defs_path)
 
     with open(args.mcap_file, "rb") as f:
         reader = make_reader(f)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mcap_schema_cli import cli  # noqa: E402
+
+
+def test_cli_invokes_node_when_no_defs(tmp_path):
+    mcap_path = tmp_path / "test.mcap"
+    mcap_path.write_bytes(b"")
+
+    called = {}
+
+    def fake_run(cmd, check):
+        called["cmd"] = cmd
+        Path(cmd[-1]).write_text("{}")
+        return CompletedProcess(cmd, 0)
+
+    class FakeReader:
+        def iter_messages(self):
+            return []
+
+    with patch("subprocess.run", side_effect=fake_run):
+        with patch("mcap_schema_cli.cli.make_reader", return_value=FakeReader()):
+            sys.argv = ["prog", "--mcap-file", str(mcap_path)]
+            cli.main()
+
+    assert called["cmd"][0] == "mcap-schema-cli"


### PR DESCRIPTION
## Summary
- auto-extract type definitions by invoking Node `mcap-schema-cli` when none provided
- document single-command usage
- add tests for automatic schema extraction

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ed0f047388330aee909c0838fb097