### PR TITLE
Add MCAP generator and end-to-end tests for ROS 2 encodings

### DIFF
--- a/tests/generate_mcap.py
+++ b/tests/generate_mcap.py
@@ -1,0 +1,33 @@
+import argparse
+from mcap.writer import Writer
+
+def encode_cdr_string(value: str) -> bytes:
+    data = value.encode('utf-8') + b"\x00"
+    length = len(data)
+    return length.to_bytes(4, 'little') + data
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a simple MCAP file")
+    parser.add_argument("output", help="Path to output MCAP file")
+    parser.add_argument("--encoding", choices=["ros2msg", "ros2idl"], default="ros2msg")
+    args = parser.parse_args()
+
+    schema_data_map = {
+        "ros2msg": b"string data\n",
+        "ros2idl": b"struct String { string data; };",
+    }
+    schema_data = schema_data_map[args.encoding]
+
+    cdr = (0).to_bytes(4, "little") + encode_cdr_string("hello")
+
+    with open(args.output, "wb") as f:
+        writer = Writer(f)
+        writer.start(profile="", library="test")
+        schema_id = writer.register_schema(name="String", encoding=args.encoding, data=schema_data)
+        channel_id = writer.register_channel(topic="String", message_encoding="cdr", schema_id=schema_id)
+        writer.add_message(channel_id=channel_id, log_time=0, publish_time=0, data=cdr)
+        writer.finish()
+
+if __name__ == "__main__":
+    main()

--- a/tests/generate_mcap.py
+++ b/tests/generate_mcap.py
@@ -1,10 +1,12 @@
 import argparse
+
 from mcap.writer import Writer
 
+
 def encode_cdr_string(value: str) -> bytes:
-    data = value.encode('utf-8') + b"\x00"
+    data = value.encode("utf-8") + b"\x00"
     length = len(data)
-    return length.to_bytes(4, 'little') + data
+    return length.to_bytes(4, "little") + data
 
 
 def main():
@@ -24,10 +26,15 @@ def main():
     with open(args.output, "wb") as f:
         writer = Writer(f)
         writer.start(profile="", library="test")
-        schema_id = writer.register_schema(name="String", encoding=args.encoding, data=schema_data)
-        channel_id = writer.register_channel(topic="String", message_encoding="cdr", schema_id=schema_id)
+        schema_id = writer.register_schema(
+            name="String", encoding=args.encoding, data=schema_data
+        )
+        channel_id = writer.register_channel(
+            topic="String", message_encoding="cdr", schema_id=schema_id
+        )
         writer.add_message(channel_id=channel_id, log_time=0, publish_time=0, data=cdr)
         writer.finish()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,4 +1,3 @@
-import json
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from mcap.reader import make_reader
+
 from mcap_schema_cli.cdr_reader import CdrReader
 from mcap_schema_cli.idl_loader import load_idl
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from mcap.reader import make_reader
+from mcap_schema_cli.cdr_reader import CdrReader
+from mcap_schema_cli.idl_loader import load_idl
+
+GENERATE_SCRIPT = Path(__file__).parent / "generate_mcap.py"
+
+
+@pytest.mark.parametrize("encoding", ["ros2msg", "ros2idl"])
+def test_end_to_end(tmp_path, encoding):
+    mcap_path = tmp_path / "test.mcap"
+    subprocess.run(
+        [sys.executable, str(GENERATE_SCRIPT), str(mcap_path), "--encoding", encoding],
+        check=True,
+    )
+
+    subprocess.run(["npm", "run", "build"], check=True)
+    types_path = tmp_path / "types.json"
+    subprocess.run(
+        ["node", "dist/index.js", str(mcap_path), "-o", str(types_path)], check=True
+    )
+
+    schemas = load_idl(str(types_path))
+    info = next(iter(schemas.values()))
+    reader = CdrReader(info.type_map, info.enum_map)
+
+    with open(mcap_path, "rb") as f:
+        r = make_reader(f)
+        for schema, channel, msg in r.iter_messages():
+            decoded = reader.read(schema.name, msg.data)
+            assert decoded["data"] == "hello"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "src/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "src/__tests__"
   ]
 }


### PR DESCRIPTION
## Summary
- add script to generate MCAP files with ros2msg or ros2idl schema encodings
- create end-to-end test covering both encodings and verifying message decoding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eedee55ac8330868880a2529cfa0e