### PR TITLE
Add ROS2 MCAP generator and end-to-end tests

### DIFF
--- a/generate_mcap.py
+++ b/generate_mcap.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Generate an MCAP file containing a std_msgs/msg/String message.
+
+The schema encoding can be either ROS 2 .msg or IDL depending on the
+selected ``--encoding`` option.
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+
+from mcap.writer import Writer
+
+ROS2MSG_DEF = "string data\n"
+ROS2IDL_DEF = (
+    "module std_msgs {\n"
+    "  module msg {\n"
+    "    struct String {\n"
+    "      string data;\n"
+    "    };\n"
+    "  };\n"
+    "};\n"
+)
+
+
+def encode_string(message: str) -> bytes:
+    """Encode a ``std_msgs/msg/String`` message as CDR."""
+    data = message.encode("utf-8")
+    length = len(data) + 1  # include null terminator
+    return b"\x00\x00\x00\x00" + struct.pack("<I", length) + data + b"\x00"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--encoding", choices=["ros2msg", "ros2idl"], required=True)
+    parser.add_argument("--output", required=True, help="Path to output MCAP file")
+    parser.add_argument(
+        "--data", default="hello", help="String data to encode in the message"
+    )
+    args = parser.parse_args()
+
+    if args.encoding == "ros2msg":
+        schema_data = ROS2MSG_DEF
+    else:
+        schema_data = ROS2IDL_DEF
+
+    with open(args.output, "wb") as f:
+        writer = Writer(f)
+        writer.start(profile="", library="mcap-generator")
+        schema_id = writer.register_schema(
+            name="std_msgs/msg/String",
+            encoding=args.encoding,
+            data=schema_data.encode("utf-8"),
+        )
+        channel_id = writer.register_channel(
+            schema_id=schema_id,
+            topic="std_msgs/msg/String",
+            message_encoding="cdr",
+            metadata={},
+        )
+        writer.add_message(
+            channel_id=channel_id,
+            log_time=0,
+            publish_time=0,
+            sequence=0,
+            data=encode_string(args.data),
+        )
+        writer.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generator_e2e.py
+++ b/tests/test_generator_e2e.py
@@ -1,0 +1,44 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mcap_schema_cli.cdr_reader import CdrReader  # noqa: E402
+from mcap_schema_cli.idl_loader import load_idl  # noqa: E402
+from mcap.reader import make_reader  # noqa: E402
+
+
+@pytest.fixture(scope="session")
+def build_cli() -> None:
+    subprocess.run(["npm", "run", "build"], check=True)
+
+
+@pytest.mark.parametrize("encoding", ["ros2msg", "ros2idl"])
+def test_generate_and_decode(tmp_path, build_cli, encoding):
+    mcap_path = tmp_path / "test.mcap"
+    types_path = tmp_path / "types.json"
+
+    script = Path(__file__).resolve().parents[1] / "generate_mcap.py"
+    subprocess.run(
+        [sys.executable, str(script), "--encoding", encoding, "--output", str(mcap_path)],
+        check=True,
+    )
+
+    subprocess.run(
+        ["node", "dist/index.js", str(mcap_path), "-o", str(types_path)],
+        check=True,
+    )
+
+    schemas = load_idl(str(types_path))
+    readers = {
+        sid: CdrReader(info.type_map, info.enum_map) for sid, info in schemas.items()
+    }
+
+    with open(mcap_path, "rb") as f:
+        reader = make_reader(f)
+        for topic, schema, message in reader.iter_messages():
+            decoded = readers[schema.schema_id].read(topic.name, message.data)
+            assert decoded["data"] == "hello"


### PR DESCRIPTION
## Summary
- add script to generate MCAP files with ros2msg or ros2idl schemas
- add test verifying generated files decode to "hello"

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688eedee55ac8330868880a2529cfa0e