### PR TITLE
refactor: modularize schema extraction

### DIFF
--- a/src/__tests__/parseSchemas.test.ts
+++ b/src/__tests__/parseSchemas.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Schema } from "@mcap/core/dist/esm/src/types.js";
+import { buildOutputData } from "../parseSchemas.js";
+
+const encoder = new TextEncoder();
+
+test("buildOutputData converts schemas to definitions", async () => {
+  const schemas: Record<string, Schema> = {
+    "1": { id: 1, name: "string", encoding: "ros2msg", data: encoder.encode("string data") },
+    "2": {
+      id: 2,
+      name: "test/Msg",
+      encoding: "ros2idl",
+      data: encoder.encode("module test { struct Msg { string data; }; };"),
+    },
+  };
+
+  const output = await buildOutputData(schemas);
+  assert.equal(output["1"][0].name, "string");
+  assert.equal(output["1"][0].definitions[0].name, "data");
+  assert.equal(output["1"][0].definitions[0].type, "string");
+  assert.equal(output["2"][0].name, "test/Msg");
+  assert.equal(output["2"][0].definitions[0].name, "data");
+});

--- a/src/__tests__/readSchemas.test.ts
+++ b/src/__tests__/readSchemas.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm, open } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { McapWriter } from "@mcap/core";
+import { FileHandleWritable } from "@mcap/nodejs";
+import { readSchemas } from "../readSchemas.js";
+
+const encoder = new TextEncoder();
+
+test("readSchemas reads schemas from an MCAP file", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "mcap-schema-cli-"));
+  const mcapPath = join(dir, "test.mcap");
+  const handle = await open(mcapPath, "w");
+  const writer = new McapWriter({
+    writable: new FileHandleWritable(handle),
+    useSummaryOffsets: true,
+    useMessageIndex: true,
+  });
+
+  try {
+    await writer.start({ profile: "", library: "test" });
+    const schemaId = await writer.registerSchema({
+      name: "string",
+      encoding: "ros2msg",
+      data: encoder.encode("string data"),
+    });
+    const channelId = await writer.registerChannel({
+      schemaId,
+      topic: "/test",
+      messageEncoding: "json",
+      metadata: new Map(),
+    });
+    await writer.addMessage({
+      channelId,
+      sequence: 0,
+      logTime: 0n,
+      publishTime: 0n,
+      data: encoder.encode("hello"),
+    });
+    await writer.end();
+    await handle.close();
+
+    const schemas = await readSchemas(mcapPath);
+    const schema = schemas[String(schemaId)];
+    assert.ok(schema);
+    assert.equal(schema.name, "string");
+    assert.equal(schema.encoding, "ros2msg");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,48 +1,16 @@
 #!/usr/bin/env node
-import { FileHandleReadable } from "@mcap/nodejs";
 import { Command } from "commander";
-import { MessageDefinition } from "@foxglove/message-definition";
-import { open } from "fs/promises";
-import { McapIndexedReader } from "@mcap/core";
-import { parseRos2idl } from "@foxglove/ros2idl-parser";
 import * as fs from "fs";
-import { parse as parseRos2msg } from "@foxglove/rosmsg";
 import { stdout } from "process";
-import { Console } from "console";
-import { Schema } from "@mcap/core/dist/esm/src/types.js";
+import type { MessageDefinition } from "@foxglove/message-definition";
+import { readSchemas } from "./readSchemas.js";
+import { buildOutputData } from "./parseSchemas.js";
 
-const logger = new Console(process.stderr);
+function writeOutput(data: Record<string, MessageDefinition[]>, out: number | string): void {
+  fs.writeFileSync(out, JSON.stringify(data, null, 2));
+}
 
 const program = new Command();
-
-async function dumpSchemasAsText(inputPath: string) {
-  const fileHandle = await open(inputPath, "r");
-
-  const reader = await McapIndexedReader.Initialize({
-    readable: new FileHandleReadable(fileHandle),
-  });
-
-  const schema_texts: { [id: string]: Schema } = {};
-
-  const decoder = new TextDecoder("utf-8");
-  for (const schema of reader.schemasById.values()) {
-    if (schema.encoding !== "ros2idl" && schema.encoding !== "ros2msg") {
-      throw new Error(`Unsupported schema encoding: ${schema.encoding}`);
-    }
-    const idlText = decoder.decode(schema.data);
-    // if the schema contains "union", skip it
-    if (idlText.includes("union")) {
-      logger.warn(
-        `Skipping schema with union: ${schema.id}, name: ${schema.name}, encoding: ${schema.encoding}`,
-      );
-      continue;
-    }
-    // Store the schema text with its encoding
-    schema_texts[schema.id] = schema;
-  }
-  fileHandle.close();
-  return schema_texts;
-}
 
 program
   .name("mcap-schema-cli")
@@ -50,54 +18,30 @@ program
   .version("0.0.1")
   .argument("<mcapFile>", "Path to the MCAP file")
   .option("-o, --output <file>", "Output JSON file (optional)")
-  .action(async (mcapFile, options) => {
+  .action(async (mcapFile: string, options: { output?: string }) => {
     if (!mcapFile) {
-      logger.error("Please provide a path to the MCAP file.");
+      console.error("Please provide a path to the MCAP file.");
       process.exit(1);
     }
     if (!fs.existsSync(mcapFile)) {
-      logger.error(`MCAP file not found: ${mcapFile}`);
+      console.error(`MCAP file not found: ${mcapFile}`);
       process.exit(1);
     }
     if (!mcapFile.endsWith(".mcap")) {
-      logger.error("The provided file is not a valid MCAP file.");
+      console.error("The provided file is not a valid MCAP file.");
       process.exit(1);
     }
-    // Log the input file and output file
-    logger.log(`Input MCAP file: ${mcapFile}`);
-    if (options.output) {
-      logger.log(`Output file: ${options.output}`);
-    } else {
-      logger.log("No output file specified, results will be printed to stdout.");
-    }
-
-    logger.log(`Processing MCAP file: ${mcapFile}`);
+    console.error(`Processing MCAP file: ${mcapFile}`);
     const outputFile = options.output || stdout.fd;
-    logger.log(`Output will be written to: ${outputFile}`);
     try {
-      const schemasById = await dumpSchemasAsText(mcapFile);
-      const outputData: { [id: string]: MessageDefinition[] } = {};
-      const decoder = new TextDecoder("utf-8");
-      for (const schema of Object.values(schemasById)) {
-        const idlText: string = decoder.decode(schema.data);
-        if (schema.encoding === "ros2idl") {
-          outputData[schema.id] = await parseRos2idl(idlText);
-        } else if (schema.encoding === "ros2msg") {
-          const definitions = await parseRos2msg(idlText);
-          definitions[0]["name"] = schema.name; // Set the name to the schema ID
-          outputData[schema.id] = definitions;
-        } else {
-          logger.warn(
-            `Unsupported schema encoding: ${schema.encoding} for schema ID: ${schema.id}`,
-          );
-          continue;
-        }
+      const schemasById = await readSchemas(mcapFile);
+      const outputData = await buildOutputData(schemasById);
+      writeOutput(outputData, outputFile);
+      if (typeof outputFile === "string") {
+        console.error(`Schemas have been written to ${outputFile}`);
       }
-      fs.writeFileSync(outputFile, JSON.stringify(outputData, null, 2));
-      logger.log("");
-      logger.log(`Schemas have been written to ${outputFile}`);
     } catch (error) {
-      logger.error("Error processing MCAP file:", error);
+      console.error("Error processing MCAP file:", error);
       process.exit(1);
     }
   });

--- a/src/parseSchemas.ts
+++ b/src/parseSchemas.ts
@@ -14,7 +14,9 @@ export async function buildOutputData(
       output[schema.id] = await parseRos2idl(idlText);
     } else if (schema.encoding === "ros2msg") {
       const definitions = await parseRos2msg(idlText);
-      definitions[0].name = schema.name;
+      if (definitions.length > 0) {
+        definitions[0].name = schema.name;
+      }
       output[schema.id] = definitions;
     } else {
       console.warn(`Unsupported schema encoding: ${schema.encoding} for schema ID: ${schema.id}`);

--- a/src/parseSchemas.ts
+++ b/src/parseSchemas.ts
@@ -1,0 +1,24 @@
+import type { MessageDefinition } from "@foxglove/message-definition";
+import { parseRos2idl } from "@foxglove/ros2idl-parser";
+import { parse as parseRos2msg } from "@foxglove/rosmsg";
+import type { Schema } from "@mcap/core/dist/esm/src/types.js";
+
+export async function buildOutputData(
+  schemasById: Record<string, Schema>,
+): Promise<Record<string, MessageDefinition[]>> {
+  const output: Record<string, MessageDefinition[]> = {};
+  const decoder = new TextDecoder("utf-8");
+  for (const schema of Object.values(schemasById)) {
+    const idlText = decoder.decode(schema.data);
+    if (schema.encoding === "ros2idl") {
+      output[schema.id] = await parseRos2idl(idlText);
+    } else if (schema.encoding === "ros2msg") {
+      const definitions = await parseRos2msg(idlText);
+      definitions[0].name = schema.name;
+      output[schema.id] = definitions;
+    } else {
+      console.warn(`Unsupported schema encoding: ${schema.encoding} for schema ID: ${schema.id}`);
+    }
+  }
+  return output;
+}

--- a/src/readSchemas.ts
+++ b/src/readSchemas.ts
@@ -1,0 +1,32 @@
+import { FileHandleReadable } from "@mcap/nodejs";
+import { McapIndexedReader } from "@mcap/core";
+import { open } from "fs/promises";
+import type { Schema } from "@mcap/core/dist/esm/src/types.js";
+
+export async function readSchemas(inputPath: string): Promise<Record<string, Schema>> {
+  const fileHandle = await open(inputPath, "r");
+  try {
+    const reader = await McapIndexedReader.Initialize({
+      readable: new FileHandleReadable(fileHandle),
+    });
+
+    const schemas: Record<string, Schema> = {};
+    const decoder = new TextDecoder("utf-8");
+    for (const schema of reader.schemasById.values()) {
+      if (schema.encoding !== "ros2idl" && schema.encoding !== "ros2msg") {
+        throw new Error(`Unsupported schema encoding: ${schema.encoding}`);
+      }
+      const idlText = decoder.decode(schema.data);
+      if (idlText.includes("union")) {
+        console.warn(
+          `Skipping schema with union: ${schema.id}, name: ${schema.name}, encoding: ${schema.encoding}`,
+        );
+        continue;
+      }
+      schemas[schema.id] = schema;
+    }
+    return schemas;
+  } finally {
+    await fileHandle.close();
+  }
+}


### PR DESCRIPTION
## Summary
- simplify logging by using console
- extract schema reading and parsing into dedicated modules
- centralize JSON emission into a single helper
- add tests demonstrating usage of schema helpers

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `node --test dist/__tests__`


------
https://chatgpt.com/codex/tasks/task_e_688f4535fea083308a89e2a90d44ee9d