### PR TITLE
Ensure Python workflow installs project dependencies

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -e . -r requirements-dev.txt
       - name: Check formatting
         run: |
           black --check mcap_schema_cli tests


### PR DESCRIPTION
## Summary
- install the package and dev dependencies in the Python CI workflow so runtime deps are present

## Testing
- `black --check mcap_schema_cli tests`
- `isort --check-only mcap_schema_cli tests -v`
- `flake8 mcap_schema_cli tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f49aa6c1483308a802d07896a9405