### PR TITLE
Add console entry point

### DIFF
--- a/mcap_schema_cli/__main__.py
+++ b/mcap_schema_cli/__main__.py
@@ -1,4 +1,3 @@
 from .cli import main
 
-if __name__ == "__main__":
-    main()
+main()

--- a/mcap_schema_cli/cli.py
+++ b/mcap_schema_cli/cli.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess
+import sys
 import tempfile
 from argparse import ArgumentParser
 
@@ -14,7 +15,10 @@ from .idl_loader import load_idl
 
 def main() -> None:
     """Entry point for the ``mcap-schema-cli`` command."""
-    parser = ArgumentParser(description="Read CDR messages from MCAP files.")
+    prog = "mcap-schema-cli"
+    if sys.argv[0].endswith("__main__.py"):
+        prog = f"{os.path.basename(sys.executable)} -m mcap_schema_cli"
+    parser = ArgumentParser(prog=prog, description="Read CDR messages from MCAP files.")
     parser.add_argument(
         "--type-definitions",
         type=str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
+[project.scripts]
+mcap-schema-cli = "mcap_schema_cli.cli:main"
+
 [tool.setuptools]
 packages = ["mcap_schema_cli"]
 


### PR DESCRIPTION
## Summary
- add project script to expose `mcap-schema-cli` command
- align `__main__` to run CLI entry point
- display friendly name when run as a module

## Testing
- `python -m mcap_schema_cli --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f48a88ed08330babf60aefa0791e5