### PR TITLE
Add Node JS CLI wrapper and include build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-dist
 
 .venv
 __pycache__/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include mcap_schema_cli/dist/index.js
+include mcap_schema_cli/dist/parseSchemas.js
+include mcap_schema_cli/dist/readSchemas.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import * as fs from "fs";
+import { stdout } from "process";
+import { readSchemas } from "./readSchemas.js";
+import { buildOutputData } from "./parseSchemas.js";
+function writeOutput(data, out) {
+    fs.writeFileSync(out, JSON.stringify(data, null, 2));
+}
+const program = new Command();
+program
+    .name("mcap-schema-cli")
+    .description("Extract schema definitions from an MCAP file")
+    .version("0.0.1")
+    .argument("<mcapFile>", "Path to the MCAP file")
+    .option("-o, --output <file>", "Output JSON file (optional)")
+    .action(async (mcapFile, options) => {
+    if (!mcapFile) {
+        console.error("Please provide a path to the MCAP file.");
+        process.exit(1);
+    }
+    if (!fs.existsSync(mcapFile)) {
+        console.error(`MCAP file not found: ${mcapFile}`);
+        process.exit(1);
+    }
+    if (!mcapFile.endsWith(".mcap")) {
+        console.error("The provided file is not a valid MCAP file.");
+        process.exit(1);
+    }
+    console.error(`Processing MCAP file: ${mcapFile}`);
+    const outputFile = options.output || stdout.fd;
+    try {
+        const schemasById = await readSchemas(mcapFile);
+        const outputData = await buildOutputData(schemasById);
+        writeOutput(outputData, outputFile);
+        if (typeof outputFile === "string") {
+            console.error(`Schemas have been written to ${outputFile}`);
+        }
+    }
+    catch (error) {
+        console.error("Error processing MCAP file:", error);
+        process.exit(1);
+    }
+});
+program.parse();

--- a/dist/parseSchemas.js
+++ b/dist/parseSchemas.js
@@ -1,0 +1,23 @@
+import { parseRos2idl } from "@foxglove/ros2idl-parser";
+import { parse as parseRos2msg } from "@foxglove/rosmsg";
+export async function buildOutputData(schemasById) {
+    const output = {};
+    const decoder = new TextDecoder("utf-8");
+    for (const schema of Object.values(schemasById)) {
+        const idlText = decoder.decode(schema.data);
+        if (schema.encoding === "ros2idl") {
+            output[schema.id] = await parseRos2idl(idlText);
+        }
+        else if (schema.encoding === "ros2msg") {
+            const definitions = await parseRos2msg(idlText);
+            if (definitions.length > 0) {
+                definitions[0].name = schema.name;
+            }
+            output[schema.id] = definitions;
+        }
+        else {
+            console.warn(`Unsupported schema encoding: ${schema.encoding} for schema ID: ${schema.id}`);
+        }
+    }
+    return output;
+}

--- a/dist/readSchemas.js
+++ b/dist/readSchemas.js
@@ -1,0 +1,28 @@
+import { FileHandleReadable } from "@mcap/nodejs";
+import { McapIndexedReader } from "@mcap/core";
+import { open } from "fs/promises";
+export async function readSchemas(inputPath) {
+    const fileHandle = await open(inputPath, "r");
+    try {
+        const reader = await McapIndexedReader.Initialize({
+            readable: new FileHandleReadable(fileHandle),
+        });
+        const schemas = {};
+        const decoder = new TextDecoder("utf-8");
+        for (const schema of reader.schemasById.values()) {
+            if (schema.encoding !== "ros2idl" && schema.encoding !== "ros2msg") {
+                throw new Error(`Unsupported schema encoding: ${schema.encoding}`);
+            }
+            const idlText = decoder.decode(schema.data);
+            if (idlText.includes("union")) {
+                console.warn(`Skipping schema with union: ${schema.id}, name: ${schema.name}, encoding: ${schema.encoding}`);
+                continue;
+            }
+            schemas[schema.id] = schema;
+        }
+        return schemas;
+    }
+    finally {
+        await fileHandle.close();
+    }
+}

--- a/mcap_schema_cli/dist/index.js
+++ b/mcap_schema_cli/dist/index.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import * as fs from "fs";
+import { stdout } from "process";
+import { readSchemas } from "./readSchemas.js";
+import { buildOutputData } from "./parseSchemas.js";
+function writeOutput(data, out) {
+    fs.writeFileSync(out, JSON.stringify(data, null, 2));
+}
+const program = new Command();
+program
+    .name("mcap-schema-cli")
+    .description("Extract schema definitions from an MCAP file")
+    .version("0.0.1")
+    .argument("<mcapFile>", "Path to the MCAP file")
+    .option("-o, --output <file>", "Output JSON file (optional)")
+    .action(async (mcapFile, options) => {
+    if (!mcapFile) {
+        console.error("Please provide a path to the MCAP file.");
+        process.exit(1);
+    }
+    if (!fs.existsSync(mcapFile)) {
+        console.error(`MCAP file not found: ${mcapFile}`);
+        process.exit(1);
+    }
+    if (!mcapFile.endsWith(".mcap")) {
+        console.error("The provided file is not a valid MCAP file.");
+        process.exit(1);
+    }
+    console.error(`Processing MCAP file: ${mcapFile}`);
+    const outputFile = options.output || stdout.fd;
+    try {
+        const schemasById = await readSchemas(mcapFile);
+        const outputData = await buildOutputData(schemasById);
+        writeOutput(outputData, outputFile);
+        if (typeof outputFile === "string") {
+            console.error(`Schemas have been written to ${outputFile}`);
+        }
+    }
+    catch (error) {
+        console.error("Error processing MCAP file:", error);
+        process.exit(1);
+    }
+});
+program.parse();

--- a/mcap_schema_cli/dist/parseSchemas.js
+++ b/mcap_schema_cli/dist/parseSchemas.js
@@ -1,0 +1,23 @@
+import { parseRos2idl } from "@foxglove/ros2idl-parser";
+import { parse as parseRos2msg } from "@foxglove/rosmsg";
+export async function buildOutputData(schemasById) {
+    const output = {};
+    const decoder = new TextDecoder("utf-8");
+    for (const schema of Object.values(schemasById)) {
+        const idlText = decoder.decode(schema.data);
+        if (schema.encoding === "ros2idl") {
+            output[schema.id] = await parseRos2idl(idlText);
+        }
+        else if (schema.encoding === "ros2msg") {
+            const definitions = await parseRos2msg(idlText);
+            if (definitions.length > 0) {
+                definitions[0].name = schema.name;
+            }
+            output[schema.id] = definitions;
+        }
+        else {
+            console.warn(`Unsupported schema encoding: ${schema.encoding} for schema ID: ${schema.id}`);
+        }
+    }
+    return output;
+}

--- a/mcap_schema_cli/dist/readSchemas.js
+++ b/mcap_schema_cli/dist/readSchemas.js
@@ -1,0 +1,28 @@
+import { FileHandleReadable } from "@mcap/nodejs";
+import { McapIndexedReader } from "@mcap/core";
+import { open } from "fs/promises";
+export async function readSchemas(inputPath) {
+    const fileHandle = await open(inputPath, "r");
+    try {
+        const reader = await McapIndexedReader.Initialize({
+            readable: new FileHandleReadable(fileHandle),
+        });
+        const schemas = {};
+        const decoder = new TextDecoder("utf-8");
+        for (const schema of reader.schemasById.values()) {
+            if (schema.encoding !== "ros2idl" && schema.encoding !== "ros2msg") {
+                throw new Error(`Unsupported schema encoding: ${schema.encoding}`);
+            }
+            const idlText = decoder.decode(schema.data);
+            if (idlText.includes("union")) {
+                console.warn(`Skipping schema with union: ${schema.id}, name: ${schema.name}, encoding: ${schema.encoding}`);
+                continue;
+            }
+            schemas[schema.id] = schema;
+        }
+        return schemas;
+    }
+    finally {
+        await fileHandle.close();
+    }
+}

--- a/mcap_schema_cli/node_cli.py
+++ b/mcap_schema_cli/node_cli.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    js_path = Path(__file__).with_name("dist") / "index.js"
+    cmd = ["node", str(js_path), *sys.argv[1:]]
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,17 @@ classifiers = [
 
 [project.scripts]
 mcap-schema-cli = "mcap_schema_cli.cli:main"
+mcap-schema-cli-js = "mcap_schema_cli.node_cli:main"
 
 [tool.setuptools]
 packages = ["mcap_schema_cli"]
+
+[tool.setuptools.package-data]
+mcap_schema_cli = [
+    "dist/index.js",
+    "dist/parseSchemas.js",
+    "dist/readSchemas.js",
+]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary
- expose a Node-based CLI through Python `node_cli.py`
- ship compiled JavaScript with the Python package
- register new console script `mcap-schema-cli-js`

## Testing
- `npm test`
- `pytest`
- `flake8 mcap_schema_cli tests`
- `python -m mcap_schema_cli.node_cli --help`


------
https://chatgpt.com/codex/tasks/task_e_688f52aefaf48330a90b23260130387b