### PR TITLE
Integrate omgidl serialization into CLI

### DIFF
--- a/mcap_schema_cli/__init__.py
+++ b/mcap_schema_cli/__init__.py
@@ -1,5 +1,10 @@
 from .cdr_reader import CdrReader, Field, MessageType
 from .idl_loader import SchemaInfo, load_idl
+from python_omgidl.omgidl_serialization.message_reader import MessageReader
+from python_omgidl.omgidl_serialization.message_writer import (
+    MessageDefinitionField,
+    MessageWriter,
+)
 
 __all__ = [
     "Field",
@@ -7,4 +12,7 @@ __all__ = [
     "CdrReader",
     "SchemaInfo",
     "load_idl",
+    "MessageDefinitionField",
+    "MessageReader",
+    "MessageWriter",
 ]

--- a/mcap_schema_cli/cdr_reader.py
+++ b/mcap_schema_cli/cdr_reader.py
@@ -1,6 +1,8 @@
 import io
 import struct
 
+from python_omgidl.omgidl_serialization.message_reader import MessageReader
+
 
 class Field:
     def __init__(self, name, type, isComplex, **kwargs):
@@ -23,15 +25,20 @@ class MessageType:
 
 
 class CdrReader:
-    def __init__(self, type_map, enum_map=None):
+    def __init__(self, type_map, enum_map=None, reader_map=None):
         self.types = type_map
         self.enums = enum_map
+        self.readers: dict[str, MessageReader] = reader_map or {}
         self.stream = None
 
     def read(self, typename, data: bytes):
         self.stream = io.BytesIO(data)
         self._read_primitive("uint32")  # Skip the CDR header
-        return self._read_message(self.types[typename])
+        result = self._read_message(self.types[typename])
+        reader = self.readers.get(typename)
+        if reader:
+            result = reader.read(result)
+        return result
 
     def _align(self, size: int, base: int = 4):
         relative_offset = self.stream.tell() - base

--- a/mcap_schema_cli/cli.py
+++ b/mcap_schema_cli/cli.py
@@ -49,7 +49,7 @@ def main() -> None:
 
     schemas = load_idl(type_defs_path)
     id_to_cdr_reader = {
-        schema_id: CdrReader(info.type_map, info.enum_map)
+        schema_id: CdrReader(info.type_map, info.enum_map, info.reader_map)
         for schema_id, info in schemas.items()
     }
 

--- a/mcap_schema_cli/idl_loader.py
+++ b/mcap_schema_cli/idl_loader.py
@@ -3,14 +3,19 @@ from dataclasses import dataclass
 from typing import Dict
 
 from .cdr_reader import MessageType
+from python_omgidl.omgidl_serialization.message_reader import (
+    MessageDefinitionField,
+    MessageReader,
+)
 
 
 @dataclass
 class SchemaInfo:
-    """Container for message types and enum lookups for a schema."""
+    """Container for message and enum definitions for a schema."""
 
     type_map: Dict[str, MessageType]
     enum_map: Dict[str, dict]
+    reader_map: Dict[str, MessageReader]
 
 
 def load_idl(path: str) -> Dict[int, SchemaInfo]:
@@ -28,16 +33,32 @@ def load_idl(path: str) -> Dict[int, SchemaInfo]:
         schema_id = int(i)
         type_map: Dict[str, MessageType] = {}
         enum_map: Dict[str, dict] = {}
+        reader_map: Dict[str, MessageReader] = {}
         for type_def in schema:
+            non_constants = [
+                f for f in type_def.get("definitions", []) if not f.get("isConstant")
+            ]
             type_map[type_def["name"]] = MessageType(
-                type_def["name"], type_def["definitions"]
+                type_def["name"], non_constants
             )
+
+            fields = [
+                MessageDefinitionField(
+                    name=f["name"],
+                    type=f["type"],
+                    is_constant=f.get("isConstant", False),
+                    default_value=f.get("defaultValue"),
+                )
+                for f in type_def.get("definitions", [])
+            ]
+            reader_map[type_def["name"]] = MessageReader(fields)
+
             enum_candidates = [
                 f for f in type_def.get("definitions", []) if f.get("isConstant")
             ]
             if enum_candidates:
                 enum_lookup = {f["value"]: f["name"] for f in enum_candidates}
                 enum_map[type_def["name"]] = enum_lookup
-        id_to_schema[schema_id] = SchemaInfo(type_map, enum_map)
+        id_to_schema[schema_id] = SchemaInfo(type_map, enum_map, reader_map)
 
     return id_to_schema

--- a/tests/test_cdr_reader.py
+++ b/tests/test_cdr_reader.py
@@ -1,9 +1,14 @@
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from mcap_schema_cli.cdr_reader import CdrReader, MessageType  # noqa: E402
+from mcap_schema_cli import (  # noqa: E402
+    CdrReader,
+    MessageDefinitionField,
+    MessageReader,
+    MessageType,
+)
 
 
 def test_enum_with_uint8():
@@ -43,3 +48,15 @@ def test_enum_with_uint8():
     reader = CdrReader(type_map, enum_map)
     data = b"\x00\x00\x00\x00" + b"\x02"
     assert reader.read("Msg", data) == {"status": "OK"}
+
+
+def test_default_with_reader_map():
+    type_map = {"Msg": MessageType("Msg", [])}
+    reader_map = {
+        "Msg": MessageReader(
+            [MessageDefinitionField(name="value", type="uint32", default_value=5)]
+        )
+    }
+    reader = CdrReader(type_map, reader_map=reader_map)
+    data = b"\x00\x00\x00\x00"
+    assert reader.read("Msg", data) == {"value": 5}

--- a/tests/test_idl_loader.py
+++ b/tests/test_idl_loader.py
@@ -2,7 +2,7 @@ import json
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from mcap_schema_cli.idl_loader import load_idl  # noqa: E402
 
@@ -34,3 +34,5 @@ def test_load_idl(tmp_path):
     assert "Foo" in info.enum_map
     assert info.enum_map["Foo"][0] == "BAZ"
     assert info.type_map["Foo"].name == "Foo"
+    assert "Foo" in info.reader_map
+    assert len(info.type_map["Foo"].fields) == 1

--- a/tests/test_message_serialization.py
+++ b/tests/test_message_serialization.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from python_omgidl.omgidl_serialization.message_reader import (  # noqa: E402
     MessageReader,


### PR DESCRIPTION
## Summary
- expose message serialization utilities from `omgidl_serialization`
- construct `MessageReader` objects when loading IDL and pass them into `CdrReader`
- have CLI supply these readers so decoded messages include defaults
- test reader map default behavior

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f662a58988330ac32c56fe2b5d0a1