### PR TITLE
Use bundled Node CLI when generating type definitions

### DIFF
--- a/mcap_schema_cli/cli.py
+++ b/mcap_schema_cli/cli.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import subprocess
 import sys
 import tempfile
 from argparse import ArgumentParser
@@ -11,6 +10,7 @@ from mcap.reader import make_reader
 
 from .cdr_reader import CdrReader
 from .idl_loader import load_idl
+from .node_cli import run_node_cli
 
 
 def main() -> None:
@@ -42,10 +42,7 @@ def main() -> None:
         cleanup = True
         with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as tmp:
             type_defs_path = tmp.name
-        subprocess.run(
-            ["mcap-schema-cli", args.mcap_file, "-o", type_defs_path],
-            check=True,
-        )
+        run_node_cli([args.mcap_file, "-o", type_defs_path])
 
     schemas = load_idl(type_defs_path)
     id_to_cdr_reader = {

--- a/mcap_schema_cli/node_cli.py
+++ b/mcap_schema_cli/node_cli.py
@@ -1,11 +1,20 @@
+"""Helpers to invoke the bundled Node.js CLI."""
+
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
+from typing import Sequence
 
 
-def main() -> None:
+def run_node_cli(args: Sequence[str]) -> None:
+    """Execute the bundled Node script with ``args``.
+
+    ``args`` should contain the command line arguments passed to the Node CLI
+    *excluding* the node executable and script path.
+    """
+
     js_path = Path(__file__).with_name("dist") / "index.js"
-    cmd = ["node", str(js_path), *sys.argv[1:]]
+    cmd = ["node", str(js_path), *args]
     try:
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as e:
@@ -17,8 +26,8 @@ def main() -> None:
             print("Output:", e.output, file=sys.stderr)
         if e.stderr:
             print("Error output:", e.stderr, file=sys.stderr)
-        sys.exit(e.returncode if e.returncode is not None else 1)
+        raise
 
 
-if __name__ == "__main__":
-    main()
+__all__ = ["run_node_cli"]
+

--- a/mcap_schema_cli/node_cli.py
+++ b/mcap_schema_cli/node_cli.py
@@ -27,6 +27,3 @@ def run_node_cli(args: Sequence[str]) -> None:
         if e.stderr:
             print("Error output:", e.stderr, file=sys.stderr)
         raise
-
-
-__all__ = ["run_node_cli"]

--- a/mcap_schema_cli/node_cli.py
+++ b/mcap_schema_cli/node_cli.py
@@ -1,8 +1,8 @@
 """Helpers to invoke the bundled Node.js CLI."""
 
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 from typing import Sequence
 
 

--- a/mcap_schema_cli/node_cli.py
+++ b/mcap_schema_cli/node_cli.py
@@ -30,4 +30,3 @@ def run_node_cli(args: Sequence[str]) -> None:
 
 
 __all__ = ["run_node_cli"]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,7 +9,7 @@ description = "A command-line and Python tool to read and parse ROS 2 MCAP bag f
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "ISC"}
-authors = [{name = "Foxglove"}]
+authors = [{name = "dskkato"}]
 dependencies = [
     "mcap>=1.3.0",
 ]
@@ -24,7 +24,6 @@ classifiers = [
 
 [project.scripts]
 mcap-schema-cli = "mcap_schema_cli.cli:main"
-mcap-schema-cli-js = "mcap_schema_cli.node_cli:main"
 
 [tool.setuptools]
 packages = ["mcap_schema_cli"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { Command } from "commander";
 import * as fs from "fs";
 import { stdout } from "process";

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,10 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from unittest.mock import patch
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+sys.modules.pop("mcap_schema_cli", None)
+sys.modules.pop("mcap_schema_cli.cli", None)
 from mcap_schema_cli import cli  # noqa: E402
 
 
@@ -27,5 +29,5 @@ def test_cli_invokes_node_when_no_defs(tmp_path):
         with patch("mcap_schema_cli.cli.make_reader", return_value=FakeReader()):
             sys.argv = ["prog", "--mcap-file", str(mcap_path)]
             cli.main()
-
-    assert called["cmd"][0] == "mcap-schema-cli"
+    assert called["cmd"][0] == "node"
+    assert Path(called["cmd"][1]).name == "index.js"


### PR DESCRIPTION
## Summary
- invoke bundled Node.js CLI from Python instead of requiring a globally linked `mcap-schema-cli`
- refactor Node CLI wrapper into reusable `run_node_cli`
- adjust tests to validate bundled CLI invocation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6c97d99883308516e17b3e59188b