### PR TITLE
Specify UTF-8 encoding when loading IDL files

### DIFF
--- a/mcap_ros2idl_support/idl_loader.py
+++ b/mcap_ros2idl_support/idl_loader.py
@@ -19,7 +19,7 @@ def load_idl(path: str) -> Dict[int, SchemaInfo]:
     Returns a dictionary indexed by schema ID containing a ``SchemaInfo``
     instance with message type and enum maps.
     """
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf-8") as f:
         type_definitions = json.load(f)
 
     id_to_schema: Dict[int, SchemaInfo] = {}


### PR DESCRIPTION
## Summary
- Ensure `load_idl` reads files with UTF-8 encoding to support non-ASCII characters

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd42624a0833099b3c42251a4163f