### PR TITLE
Handle CDR endianness

### DIFF
--- a/mcap_ros2idl_support/cdr_reader.py
+++ b/mcap_ros2idl_support/cdr_reader.py
@@ -88,7 +88,9 @@ class CdrReader:
         }.get(type_name)
 
         if fmt:
-            value = struct.unpack(self.endianness + fmt, self.stream.read(struct.calcsize(fmt)))[0]
+            value = struct.unpack(
+                self.endianness + fmt, self.stream.read(struct.calcsize(fmt))
+            )[0]
         elif type_name == "string":
             length = self._read_primitive("uint32")
             bytes_ = self.stream.read(length)

--- a/mcap_ros2idl_support/cdr_reader.py
+++ b/mcap_ros2idl_support/cdr_reader.py
@@ -27,10 +27,14 @@ class CdrReader:
         self.types = type_map
         self.enums = enum_map
         self.stream = None
+        self.endianness = "<"
 
     def read(self, typename, data: bytes):
         self.stream = io.BytesIO(data)
-        self._read_primitive("uint32")  # Skip the CDR header
+        header = self.stream.read(4)
+        if len(header) < 4:
+            raise ValueError("Incomplete CDR header")
+        self.endianness = "<" if header[1] & 0x01 else ">"
         return self._read_message(self.types[typename])
 
     def _align(self, size: int, base: int = 4):
@@ -83,7 +87,7 @@ class CdrReader:
         }.get(type_name)
 
         if fmt:
-            value = struct.unpack("<" + fmt, self.stream.read(struct.calcsize(fmt)))[0]
+            value = struct.unpack(self.endianness + fmt, self.stream.read(struct.calcsize(fmt)))[0]
         elif type_name == "string":
             length = self._read_primitive("uint32")
             bytes_ = self.stream.read(length)

--- a/mcap_ros2idl_support/cdr_reader.py
+++ b/mcap_ros2idl_support/cdr_reader.py
@@ -34,7 +34,8 @@ class CdrReader:
         header = self.stream.read(4)
         if len(header) < 4:
             raise ValueError("Incomplete CDR header")
-        # According to the CDR specification, bit 0 of byte 1 indicates little endian when set.
+        # According to the CDR specification, bit 0 of byte 1 indicates
+        # little endian when set.
         self.endianness = "<" if header[1] & 0x01 else ">"
         return self._read_message(self.types[typename])
 

--- a/mcap_ros2idl_support/cdr_reader.py
+++ b/mcap_ros2idl_support/cdr_reader.py
@@ -34,6 +34,7 @@ class CdrReader:
         header = self.stream.read(4)
         if len(header) < 4:
             raise ValueError("Incomplete CDR header")
+        # According to the CDR specification, bit 0 of byte 1 indicates little endian when set.
         self.endianness = "<" if header[1] & 0x01 else ">"
         return self._read_message(self.types[typename])
 

--- a/tests/test_cdr_reader.py
+++ b/tests/test_cdr_reader.py
@@ -2,8 +2,9 @@ import struct
 import sys
 from pathlib import Path
 
-# Insert the parent directory at the start of sys.path to ensure tests use the local (uninstalled) version of the package.
-# This is intentional to avoid conflicts with installed packages and to test the current source.
+# Insert the parent directory at the start of sys.path to ensure tests
+# use the local (uninstalled) version of the package. This is intentional
+# to avoid conflicts with installed packages and to test the current source.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from mcap_ros2idl_support.cdr_reader import CdrReader, MessageType  # noqa: E402

--- a/tests/test_cdr_reader.py
+++ b/tests/test_cdr_reader.py
@@ -1,5 +1,5 @@
-import sys
 import struct
+import sys
 from pathlib import Path
 
 # Insert the parent directory at the start of sys.path to ensure tests use the local (uninstalled) version of the package.

--- a/tests/test_cdr_reader.py
+++ b/tests/test_cdr_reader.py
@@ -1,7 +1,8 @@
 import sys
+import struct
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from mcap_ros2idl_support.cdr_reader import CdrReader, MessageType  # noqa: E402
 
@@ -43,3 +44,39 @@ def test_enum_with_uint8():
     reader = CdrReader(type_map, enum_map)
     data = b"\x00\x00\x00\x00" + b"\x02"
     assert reader.read("Msg", data) == {"status": "OK"}
+
+
+def test_little_endian_uint32():
+    type_map = {
+        "Msg": MessageType(
+            "Msg",
+            [
+                {
+                    "name": "value",
+                    "type": "uint32",
+                    "isComplex": False,
+                }
+            ],
+        )
+    }
+    reader = CdrReader(type_map)
+    data = b"\x00\x01\x00\x00" + struct.pack("<I", 0x01020304)
+    assert reader.read("Msg", data) == {"value": 0x01020304}
+
+
+def test_big_endian_uint32():
+    type_map = {
+        "Msg": MessageType(
+            "Msg",
+            [
+                {
+                    "name": "value",
+                    "type": "uint32",
+                    "isComplex": False,
+                }
+            ],
+        )
+    }
+    reader = CdrReader(type_map)
+    data = b"\x00\x00\x00\x00" + struct.pack(">I", 0x01020304)
+    assert reader.read("Msg", data) == {"value": 0x01020304}

--- a/tests/test_cdr_reader.py
+++ b/tests/test_cdr_reader.py
@@ -2,6 +2,8 @@ import sys
 import struct
 from pathlib import Path
 
+# Insert the parent directory at the start of sys.path to ensure tests use the local (uninstalled) version of the package.
+# This is intentional to avoid conflicts with installed packages and to test the current source.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from mcap_ros2idl_support.cdr_reader import CdrReader, MessageType  # noqa: E402


### PR DESCRIPTION
## Summary
- detect CDR endianness from payload header
- use stored endianness for primitive decoding
- test little and big endian payload decoding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd428f54883309a6a62480760bced