### PR TITLE
Optimize CDR primitive parsing

### DIFF
--- a/mcap_ros2idl_support/cdr_reader.py
+++ b/mcap_ros2idl_support/cdr_reader.py
@@ -71,8 +71,8 @@ class CdrReader:
         }
         return self._read_message(self.types[typename])
 
-    def _align(self, size: int, base: int = 4):
-        relative_offset = self.stream.tell() - base
+    def _align(self, size: int):
+        relative_offset = self.stream.tell() - 4
         padding = (size - (relative_offset % size)) % size
         self.stream.seek(padding, io.SEEK_CUR)
 

--- a/mcap_ros2idl_support/cdr_reader.py
+++ b/mcap_ros2idl_support/cdr_reader.py
@@ -100,17 +100,23 @@ class CdrReader:
             return [read_message(msg_type) for _ in range(length)]
 
         # Primitive array fast path
-        struct_obj = self._structs[field.type]
+        struct_obj = self._structs.get(field.type)
+        if struct_obj is None:
+            raise ValueError(f"Unsupported primitive type: {field.type}")
+
         align_size = self._ALIGNMENT.get(field.type, 1)
         if align_size > 1:
             self._align(align_size)
         data = self.stream.read(struct_obj.size * length)
-        fmt_char = struct_obj.format[-1]
-        values = struct.unpack(self.endianness + fmt_char * length, data)
+
         if field.enum_type:
             enum_lookup = self.enums[field.enum_type]
-            return [enum_lookup.get(v, f"Unknown enum value: {v}") for v in values]
-        return list(values)
+            return [
+                enum_lookup.get(v, f"Unknown enum value: {v}")
+                for (v,) in struct_obj.iter_unpack(data)
+            ]
+
+        return [v for (v,) in struct_obj.iter_unpack(data)]
 
     def _read_primitive(self, type_name, enum_type=None):
         align_size = self._ALIGNMENT.get(type_name, 1)

--- a/mcap_ros2idl_support/cdr_reader.py
+++ b/mcap_ros2idl_support/cdr_reader.py
@@ -23,11 +23,26 @@ class MessageType:
 
 
 class CdrReader:
+    _ALIGNMENT = {
+        "uint8": 1,
+        "int8": 1,
+        "bool": 1,
+        "uint16": 2,
+        "int16": 2,
+        "uint32": 4,
+        "int32": 4,
+        "float32": 4,
+        "uint64": 8,
+        "int64": 8,
+        "float64": 8,
+    }
+
     def __init__(self, type_map, enum_map=None):
         self.types = type_map
         self.enums = enum_map
         self.stream = None
         self.endianness = "<"
+        self._structs: dict[str, struct.Struct] = {}
 
     def read(self, typename, data: bytes):
         self.stream = io.BytesIO(data)
@@ -37,6 +52,23 @@ class CdrReader:
         # According to the CDR specification, bit 0 of byte 1 indicates
         # little endian when set.
         self.endianness = "<" if header[1] & 0x01 else ">"
+        # Initialize cached struct objects for primitives with the current endianness
+        self._structs = {
+            name: struct.Struct(self.endianness + fmt)
+            for name, fmt in {
+                "uint8": "B",
+                "int8": "b",
+                "uint16": "H",
+                "int16": "h",
+                "int32": "i",
+                "uint32": "I",
+                "int64": "q",
+                "uint64": "Q",
+                "float32": "f",
+                "float64": "d",
+                "bool": "?",
+            }.items()
+        }
         return self._read_message(self.types[typename])
 
     def _align(self, size: int, base: int = 4):
@@ -46,52 +78,48 @@ class CdrReader:
 
     def _read_message(self, msg_type: "MessageType"):
         result = {}
+        types = self.types
+        read_array = self._read_array
+        read_message = self._read_message
+        read_primitive = self._read_primitive
         for field in msg_type.fields:
             if field.is_array:
-                result[field.name] = self._read_array(field)
+                result[field.name] = read_array(field)
             elif field.is_complex:
-                result[field.name] = self._read_message(self.types[field.type])
+                result[field.name] = read_message(types[field.type])
             else:
-                result[field.name] = self._read_primitive(field.type, field.enum_type)
+                result[field.name] = read_primitive(field.type, field.enum_type)
         return result
 
     def _read_array(self, field):
         # Sequence length is prefixed with UInt32
         length = self._read_primitive("uint32")
-        items = []
-        for _ in range(length):
-            if field.is_complex:
-                items.append(self._read_message(self.types[field.type]))
-            else:
-                items.append(self._read_primitive(field.type, field.enum_type))
-        return items
+        if field.is_complex:
+            msg_type = self.types[field.type]
+            read_message = self._read_message
+            return [read_message(msg_type) for _ in range(length)]
+
+        # Primitive array fast path
+        struct_obj = self._structs[field.type]
+        align_size = self._ALIGNMENT.get(field.type, 1)
+        if align_size > 1:
+            self._align(align_size)
+        data = self.stream.read(struct_obj.size * length)
+        fmt_char = struct_obj.format[-1]
+        values = struct.unpack(self.endianness + fmt_char * length, data)
+        if field.enum_type:
+            enum_lookup = self.enums[field.enum_type]
+            return [enum_lookup.get(v, f"Unknown enum value: {v}") for v in values]
+        return list(values)
 
     def _read_primitive(self, type_name, enum_type=None):
-        if type_name in ("uint32", "int32", "float32"):
-            self._align(4)
-        elif type_name in ("uint64", "int64", "float64"):
-            self._align(8)
-        elif type_name in ("uint16", "int16"):
-            self._align(2)
+        align_size = self._ALIGNMENT.get(type_name, 1)
+        if align_size > 1:
+            self._align(align_size)
 
-        fmt = {
-            "uint8": "B",
-            "int8": "b",
-            "uint16": "H",
-            "int16": "h",
-            "int32": "i",
-            "uint32": "I",
-            "int64": "q",
-            "uint64": "Q",
-            "float32": "f",
-            "float64": "d",
-            "bool": "?",
-        }.get(type_name)
-
-        if fmt:
-            value = struct.unpack(
-                self.endianness + fmt, self.stream.read(struct.calcsize(fmt))
-            )[0]
+        struct_obj = self._structs.get(type_name)
+        if struct_obj:
+            value = struct_obj.unpack(self.stream.read(struct_obj.size))[0]
         elif type_name == "string":
             length = self._read_primitive("uint32")
             bytes_ = self.stream.read(length)


### PR DESCRIPTION
## Summary
- cache `struct.Struct` instances and alignment info to avoid redundant unpack setup
- speed up array parsing with a fast path for primitive sequences

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68907202ecf48330bbea6ecea9d3a50f