### PR TITLE
chore: move dev setup into pyproject

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e . -r requirements-dev.txt
+          pip install -e '.[dev]'
       - name: Check formatting
         run: |
           black --check mcap_ros2idl_support tests

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ npm run deploy
 pip install .
 ```
 
+## Development
+
+Install development dependencies and run the test suite:
+
+```bash
+pip install -e '.[dev]'
+pytest
+```
+
 ## Usage
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,14 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "black",
+    "flake8",
+    "isort",
+    "pytest",
+]
+
 [project.scripts]
 mcap-ros2idl-support = "mcap_ros2idl_support.cli:main"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,0 @@
-black
-flake8
-isort
-pytest


### PR DESCRIPTION
## Summary
- manage dev dependencies through pyproject optional group
- document dev install instructions in README

## Testing
- `pip install -e '.[dev]'`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689123e10a448330ae9748b8fbd7b8d8