### PR TITLE
Add pre-commit configuration and Python dev docs

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -15,11 +15,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[dev]'
-      - name: Check formatting
-        run: |
-          black --check mcap_ros2idl_support tests
-          isort --check-only mcap_ros2idl_support tests
-      - name: Lint
-        run: flake8 mcap_ros2idl_support tests
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --all-files
       - name: Run tests
         run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -24,12 +24,7 @@ pip install .
 
 ## Development
 
-Install development dependencies and run the test suite:
-
-```bash
-pip install -e '.[dev]'
-pytest
-```
+See [README_PYTHON.md](README_PYTHON.md) for details on setting up a Python development environment, running pre-commit, and executing tests.
 
 ## Usage
 

--- a/README_PYTHON.md
+++ b/README_PYTHON.md
@@ -1,0 +1,36 @@
+# Python Development
+
+## Environment setup
+
+1. Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install project and development dependencies:
+   ```bash
+   pip install -e '.[dev]'
+   ```
+
+## Using pre-commit
+
+Install the git hooks and run them locally before committing:
+
+```bash
+pre-commit install
+pre-commit run --files <file> [<file> ...]
+```
+
+To check the entire repository, use:
+
+```bash
+pre-commit run --all-files
+```
+
+## Running tests
+
+Execute the test suite with pytest:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "black",
-    "flake8",
-    "isort",
+    "pre-commit",
     "pytest",
 ]
 


### PR DESCRIPTION
## Summary
- add pre-commit config running Black, isort, and Flake8
- drop direct black/isort/flake8 deps in favor of pre-commit
- document Python development workflow

## Testing
- `pre-commit run --files pyproject.toml .pre-commit-config.yaml README.md README_PYTHON.md mcap_ros2idl_support/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68919a83b65083309d5e573e79c7fa7a