### PR TITLE
Add Python bindings via PyO3

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,8 @@ build output doesn't conflict with Python's `dist/` directory.
 
 ## Rust prototype
 
-A lightweight Rust implementation demonstrating MCAP parsing is available in [`rust/mcap-rs`](rust/mcap-rs). The CLI accepts an MCAP file, invokes the bundled Node tool to extract type definitions, and prints each decoded message. The crate also exposes library functions for counting messages and decoding CDR payloads.
+A lightweight Rust implementation demonstrating MCAP parsing is available in [`rust/mcap-rs`](rust/mcap-rs). The CLI accepts an MCAP file, invokes the bundled Node tool to extract type definitions, and prints each decoded message. The crate also exposes library functions for counting messages and decoding CDR payloads. Python bindings for these utilities can be installed with:
+
+```bash
+maturin develop --manifest-path rust/mcap-rs/Cargo.toml
+```

--- a/README_PYTHON.md
+++ b/README_PYTHON.md
@@ -12,6 +12,11 @@
    pip install -e '.[dev]'
    ```
 
+3. Build the Rust Python bindings using `maturin`:
+   ```bash
+   maturin develop --manifest-path rust/mcap-rs/Cargo.toml
+   ```
+
 ## Using pre-commit
 
 Install the git hooks and run them locally before committing:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dev = [
     "pre-commit",
     "pytest",
+    "maturin>=1.5,<2",
 ]
 
 [project.scripts]

--- a/rust/mcap-rs/Cargo.lock
+++ b/rust/mcap-rs/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +200,12 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "itoa"
@@ -216,6 +234,16 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -268,6 +296,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "mcap",
+ "pyo3",
  "serde",
  "serde_json",
  "tempfile",
@@ -278,6 +307,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -302,6 +340,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,12 +375,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -336,6 +466,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "rustix"
@@ -355,6 +494,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -395,6 +540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +572,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -460,6 +617,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "wasi"

--- a/rust/mcap-rs/Cargo.toml
+++ b/rust/mcap-rs/Cargo.toml
@@ -3,11 +3,16 @@ name = "mcap-rs"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+name = "mcap_rs"
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 mcap = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 byteorder = "1"
+pyo3 = { version = "0.20", features = ["extension-module", "abi3-py310"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/mcap-rs/pyproject.toml
+++ b/rust/mcap-rs/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["maturin>=1,<2"]
+build-backend = "maturin"
+
+[project]
+name = "mcap_rs"
+version = "0.1.0"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: ISC License (ISCL)",
+    "Operating System :: OS Independent",
+]

--- a/rust/mcap-rs/src/lib.rs
+++ b/rust/mcap-rs/src/lib.rs
@@ -1,6 +1,8 @@
 use mcap::{McapResult, MessageStream};
 use serde::Deserialize;
 use std::{collections::HashMap, fs::File};
+use pyo3::prelude::*;
+use pyo3::types::{PyList, PyDict};
 
 pub mod cdr;
 pub use cdr::CdrReader;
@@ -39,7 +41,7 @@ pub struct MessageType {
     pub fields: Vec<Field>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SchemaInfo {
     pub type_map: HashMap<String, MessageType>,
     pub enum_map: HashMap<String, HashMap<i64, String>>, // enum type -> value -> name
@@ -94,6 +96,162 @@ pub fn count_messages(buf: &[u8]) -> McapResult<usize> {
         count += 1;
     }
     Ok(count)
+}
+
+// ---------------------------------------------------------------------------
+// Python bindings
+// ---------------------------------------------------------------------------
+
+fn json_to_py(py: Python<'_>, value: &serde_json::Value) -> PyResult<PyObject> {
+    match value {
+        serde_json::Value::Null => Ok(py.None()),
+        serde_json::Value::Bool(b) => Ok(b.to_object(py)),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(i.to_object(py))
+            } else if let Some(u) = n.as_u64() {
+                Ok(u.to_object(py))
+            } else if let Some(f) = n.as_f64() {
+                Ok(f.to_object(py))
+            } else {
+                Ok(py.None())
+            }
+        }
+        serde_json::Value::String(s) => Ok(s.to_object(py)),
+        serde_json::Value::Array(arr) => {
+            let elements: Vec<_> = arr
+                .iter()
+                .map(|v| json_to_py(py, v))
+                .collect::<PyResult<Vec<_>>>()?;
+            Ok(PyList::new(py, elements).into())
+        }
+        serde_json::Value::Object(map) => {
+            let dict = PyDict::new(py);
+            for (k, v) in map {
+                dict.set_item(k, json_to_py(py, v)?)?;
+            }
+            Ok(dict.into())
+        }
+    }
+}
+
+#[pyclass]
+pub struct SchemaRegistry {
+    schemas: HashMap<u32, SchemaInfo>,
+}
+
+#[pymethods]
+impl SchemaRegistry {
+    #[new]
+    pub fn new(files: Vec<String>) -> PyResult<Self> {
+        let mut schemas = HashMap::new();
+        for path in files {
+            let loaded = load_idl(&path)
+                .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+            schemas.extend(loaded);
+        }
+        Ok(Self { schemas })
+    }
+}
+
+#[pyclass]
+pub struct Message {
+    #[pyo3(get)]
+    channel: String,
+    #[pyo3(get)]
+    timestamp: u64,
+    #[pyo3(get)]
+    data: PyObject,
+}
+
+#[pyclass]
+pub struct MCAPReader {
+    data: Vec<u8>,
+    schemas: HashMap<u32, SchemaInfo>,
+}
+
+#[pymethods]
+impl MCAPReader {
+    #[new]
+    pub fn new(path: &str, registry: &SchemaRegistry) -> PyResult<Self> {
+        let data = std::fs::read(path)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+        Ok(Self { data, schemas: registry.schemas.clone() })
+    }
+
+    pub fn count(&self, topic: Option<&str>) -> PyResult<u64> {
+        let mut count = 0u64;
+        let mut stream = MessageStream::new(self.data.as_slice())
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        while let Some(res) = stream.next() {
+            let msg = res.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            if let Some(t) = topic {
+                if msg.channel.topic != t {
+                    continue;
+                }
+            }
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    pub fn iter(&self, py: Python<'_>, topic: Option<&str>) -> PyResult<Vec<Message>> {
+        let mut out = Vec::new();
+        let mut stream = MessageStream::new(self.data.as_slice())
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        while let Some(res) = stream.next() {
+            let msg = res.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            if let Some(t) = topic {
+                if msg.channel.topic != t {
+                    continue;
+                }
+            }
+            let schema = match &msg.channel.schema {
+                Some(s) => s,
+                None => continue,
+            };
+            let info = match self.schemas.get(&(schema.id as u32)) {
+                Some(i) => i,
+                None => continue,
+            };
+            let reader = CdrReader::new(info);
+            let type_name = schema.name.replace("::", "/");
+            let decoded = reader
+                .read(&type_name, msg.data.as_ref())
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            let py_data = json_to_py(py, &decoded)?;
+            out.push(Message { channel: msg.channel.topic.clone(), timestamp: msg.log_time, data: py_data });
+        }
+        Ok(out)
+    }
+}
+
+#[pyfunction]
+pub fn decode_cdr(
+    registry: &SchemaRegistry,
+    schema_id: u32,
+    type_name: &str,
+    data: &[u8],
+) -> PyResult<PyObject> {
+    let info = registry
+        .schemas
+        .get(&schema_id)
+        .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err("unknown schema id"))?;
+    let reader = CdrReader::new(info);
+    let value = reader
+        .read(type_name, data)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+    Python::with_gil(|py| json_to_py(py, &value))
+}
+
+#[pymodule]
+fn mcap_rs(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<SchemaRegistry>()?;
+    m.add_class::<MCAPReader>()?;
+    m.add_class::<Message>()?;
+    m.add_function(wrap_pyfunction!(decode_cdr, m)?)?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/tests/test_mcap_rs.py
+++ b/tests/test_mcap_rs.py
@@ -1,6 +1,30 @@
+import importlib
+import pathlib
+import subprocess
+import sys
 import tempfile
 
-import mcap_rs
+try:  # pragma: no cover - installation step
+    import mcap_rs  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - executed when extension missing
+    manifest = pathlib.Path(__file__).parents[1] / "rust" / "mcap-rs" / "Cargo.toml"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "maturin",
+            "build",
+            "--manifest-path",
+            str(manifest),
+            "--interpreter",
+            sys.executable,
+        ],
+        check=True,
+    )
+    wheel_dir = manifest.parent / "target" / "wheels"
+    wheel = next(wheel_dir.glob("mcap_rs-*.whl"))
+    subprocess.run([sys.executable, "-m", "pip", "install", str(wheel)], check=True)
+    mcap_rs = importlib.import_module("mcap_rs")
 
 
 def test_decode_cdr_from_rust():

--- a/tests/test_mcap_rs.py
+++ b/tests/test_mcap_rs.py
@@ -1,0 +1,17 @@
+import tempfile
+
+import mcap_rs
+
+
+def test_decode_cdr_from_rust():
+    schema_json = (
+        '{"1":[{"name":"Msg","definitions":[{"name":"value","type":"uint32",'
+        '"isComplex":false}]}]}'
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        f.write(schema_json)
+        path = f.name
+    reg = mcap_rs.SchemaRegistry([path])
+    data = bytes([0, 1, 0, 0]) + (1234).to_bytes(4, "little")
+    value = mcap_rs.decode_cdr(reg, 1, "Msg", data)
+    assert value["value"] == 1234


### PR DESCRIPTION
## Summary
- expose Rust MCAP utilities to Python using PyO3
- support SchemaRegistry, MCAPReader and CDR decoding
- add tests verifying the new bindings

## Testing
- `cargo test --manifest-path rust/mcap-rs/Cargo.toml`
- `maturin develop --manifest-path rust/mcap-rs/Cargo.toml`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ba119ed08330b674ba8e3a4e8987