### PR TITLE
Run GitHub Actions only for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  push:
   pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,8 @@
 name: Python tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,8 +1,8 @@
 name: Rust tests
 
 on:
-  push:
   pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- avoid duplicate CI runs by removing push triggers
- trigger workflows on pull_request events (opened, synchronize, reopened)

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/python-tests.yml .github/workflows/rust-tests.yml`


------
https://chatgpt.com/codex/tasks/task_e_689610fb771c8330b4339eaccc5d36b4