### PR TITLE
docs: document submodule setup and optional Node.js usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,33 @@ It extracts schemas from rosbag2 messages and decodes their CDR payloads.
 
 ## Installation
 
-Requires Node.js ≥20 and Python ≥3.10.
+Requires Python ≥3.10. Node.js ≥20 is only needed if you plan to use the Node.js CLI.
+
+This repository uses Git submodules. After cloning, initialize them with:
+
+```bash
+git submodule update --init --recursive
+```
+
+Alternatively, clone the repository with submodules already checked out:
+
+```bash
+git clone --recurse-submodules <repository-url>
+```
+
+Install the Python package:
+
+```bash
+pip install .
+```
+
+### Node.js CLI (optional)
+
+If you want to use the Node.js implementation, install Node.js ≥20 and set up the CLI:
 
 ```bash
 npm --prefix nodejs install
 npm --prefix nodejs run deploy
-```
-
-```bash
-pip install .
 ```
 
 ## Development
@@ -66,7 +84,7 @@ pip install .
 
 ### Node.js
 
-The Node.js CLI lives in [`nodejs/`](nodejs/). From that directory:
+The Node.js CLI lives in [`nodejs/`](nodejs/). It requires Node.js ≥20. From that directory:
 
 ```bash
 npm install
@@ -84,8 +102,9 @@ python3 -m mcap_ros2idl_support --mcap-file sample.mcap
 ```
 
 This command automatically invokes the bundled Node `mcap-schema-extractor` tool to
-extract type definitions before decoding messages. You can also run this Node
-tool directly during development to generate type definitions:
+extract type definitions before decoding messages. The Python package bundles a prebuilt
+executable, so Node.js is not required for normal operation. If you have Node.js installed
+and want to run the tool directly during development, use:
 
 ```bash
 npm --prefix nodejs run dev -- sample.mcap -o types.json


### PR DESCRIPTION
## Summary
- document required git submodule initialization commands
- clarify that Node.js is optional and add setup instructions for the optional CLI

## Testing
- `pre-commit run --files README.md`


------
https://chatgpt.com/codex/tasks/task_e_6897ef5343988330bccae45fd63e5282