### PR TITLE
Add ROS 2 CDR decode factory for McapReader

### DIFF
--- a/mcap_ros2idl_support/__init__.py
+++ b/mcap_ros2idl_support/__init__.py
@@ -1,4 +1,5 @@
 from .cdr_reader import CdrReader, Field, MessageType
+from .decode_factory import CdrDecodeFactory, make_decoder_factory
 from .idl_loader import SchemaInfo, load_idl
 
 __all__ = [
@@ -7,4 +8,6 @@ __all__ = [
     "CdrReader",
     "SchemaInfo",
     "load_idl",
+    "CdrDecodeFactory",
+    "make_decoder_factory",
 ]

--- a/mcap_ros2idl_support/cli.py
+++ b/mcap_ros2idl_support/cli.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 
 from mcap.reader import make_reader
 
-from .cdr_reader import CdrReader
+from .decode_factory import CdrDecodeFactory
 from .idl_loader import load_idl
 from .node_cli import run_node_cli
 
@@ -44,20 +44,13 @@ def main() -> None:
 
         schemas = load_idl_py(args.mcap_file)
 
-    id_to_cdr_reader = {
-        schema_id: CdrReader(info.type_map, info.enum_map)
-        for schema_id, info in schemas.items()
-    }
+    factory = CdrDecodeFactory(schemas)
 
     with open(args.mcap_file, "rb") as f:
-        reader = make_reader(f)
-        for topic, schema, message in reader.iter_messages():
-            print(f"Topic: {topic}, Schema ID: {schema.schema_id}")
-            if schema.schema_id not in id_to_cdr_reader:
-                print(f"Schema ID {schema.schema_id} not found in type definitions.")
-                continue
-            msg = id_to_cdr_reader[schema.schema_id].read(topic.name, message.data)
-            print(json.dumps(msg, indent=2))
+        reader = make_reader(f, decoder_factories=[factory])
+        for decoded in reader.iter_decoded_messages():
+            print(f"Topic: {decoded.channel.topic}, Schema ID: {decoded.schema.id}")
+            print(json.dumps(decoded.decoded_message, indent=2))
 
 
 if __name__ == "__main__":

--- a/mcap_ros2idl_support/decode_factory.py
+++ b/mcap_ros2idl_support/decode_factory.py
@@ -1,0 +1,55 @@
+"""DecodeFactory integrating CDR decoding with the mcap reader."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from mcap.decoder import DecoderFactory
+from mcap.records import Schema
+
+from .cdr_reader import CdrReader
+from .idl_loader import SchemaInfo
+
+
+class CdrDecodeFactory(DecoderFactory):
+    """DecodeFactory for CDR-encoded ROS 2 messages.
+
+    Instances of this factory can be supplied to
+    :py:meth:`mcap.reader.make_reader` so that calls to
+    :py:meth:`mcap.reader.McapReader.iter_decoded_messages` will return
+    dictionaries representing ROS 2 messages.
+    """
+
+    def __init__(self, schemas: dict[int, SchemaInfo]):
+        self._readers: dict[int, CdrReader] = {
+            schema_id: CdrReader(info.type_map, info.enum_map)
+            for schema_id, info in schemas.items()
+        }
+
+    def decoder_for(
+        self, message_encoding: str, schema: Optional[Schema]
+    ) -> Optional[Callable[[bytes], object]]:
+        if message_encoding != "cdr" or schema is None:
+            return None
+        reader = self._readers.get(schema.id)
+        if reader is None:
+            return None
+        type_name = schema.name.replace("::", "/")
+
+        def decode(data: bytes) -> object:
+            return reader.read(type_name, data)
+
+        return decode
+
+
+def make_decoder_factory(mcap_file: str) -> CdrDecodeFactory:
+    """Create a :class:`CdrDecodeFactory` from an MCAP file.
+
+    This convenience function parses the schemas embedded in ``mcap_file``
+    using the pure-Python IDL loader and returns a decode factory ready to be
+    supplied to :py:meth:`mcap.reader.make_reader`.
+    """
+    from .idl_loader_py import load_idl as load_idl_py
+
+    schemas = load_idl_py(mcap_file)
+    return CdrDecodeFactory(schemas)

--- a/tests/test_decode_factory.py
+++ b/tests/test_decode_factory.py
@@ -1,0 +1,39 @@
+import struct
+import sys
+from pathlib import Path
+
+# Ensure local package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mcap.reader import make_reader  # noqa: E402
+from mcap.writer import Writer  # noqa: E402
+
+from mcap_ros2idl_support import CdrDecodeFactory, MessageType, SchemaInfo  # noqa: E402
+
+
+def test_decode_factory_integration(tmp_path):
+    type_map = {
+        "Msg": MessageType(
+            "Msg",
+            [{"name": "value", "type": "uint32", "isComplex": False}],
+        )
+    }
+    info = SchemaInfo(type_map, {})
+    factory = CdrDecodeFactory({1: info})
+
+    mcap_path = tmp_path / "test.mcap"
+    with open(mcap_path, "wb") as f:
+        writer = Writer(f)
+        writer.start()
+        schema_id = writer.register_schema("Msg", "ros2msg", b"")
+        channel_id = writer.register_channel("/test", "cdr", schema_id)
+        data = b"\x00\x01\x00\x00" + struct.pack("<I", 42)
+        writer.add_message(channel_id, 0, data, 0)
+        writer.finish()
+
+    with open(mcap_path, "rb") as f:
+        reader = make_reader(f, decoder_factories=[factory])
+        decoded = list(reader.iter_decoded_messages())
+        assert len(decoded) == 1
+        _, _, _, msg = decoded[0]
+        assert msg == {"value": 42}


### PR DESCRIPTION
## Summary
- add `CdrDecodeFactory` to integrate CDR decoding with `mcap.reader`
- expose decode factory and helper from package root
- test decoding MCAP messages via the new factory
- use `CdrDecodeFactory` in CLI for message decoding

## Testing
- `pre-commit run --files mcap_ros2idl_support/cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897f2026a20833083e691602701329e