### PR TITLE
Use SimpleNamespace for decoded messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It extracts schemas from rosbag2 messages and decodes their CDR payloads.
 
 - Read-only parsing of MCAP/rosbag2 files without needing a ROS 2 runtime
 - Supports ROS 2 IDL (including potential enum support) through [@foxglove/ros2idl-parser](https://www.npmjs.com/package/@foxglove/ros2idl-parser)
-- Treats each struct as a Python `dict` instead of generating dynamic classes
+- Parses each struct into a `SimpleNamespace` for attribute-style access
 
 ## Installation
 

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -49,7 +49,7 @@ def main() -> None:
         reader = make_reader(f, decoder_factories=[factory])
         for decoded in reader.iter_decoded_messages():
             print(f"Topic: {decoded.channel.topic}, Schema ID: {decoded.schema.id}")
-            print(json.dumps(decoded.decoded_message, indent=2))
+            print(json.dumps(vars(decoded.decoded_message), indent=2))
 
 
 if __name__ == "__main__":

--- a/mcap_ros2idl_support/cdr_reader.py
+++ b/mcap_ros2idl_support/cdr_reader.py
@@ -1,5 +1,6 @@
 import io
 import struct
+from types import SimpleNamespace
 
 
 class Field:
@@ -44,7 +45,7 @@ class CdrReader:
         self.endianness = "<"
         self._structs: dict[str, struct.Struct] = {}
 
-    def read(self, typename, data: bytes):
+    def read(self, typename, data: bytes) -> SimpleNamespace:
         self.stream = io.BytesIO(data)
         header = self.stream.read(4)
         if len(header) < 4:
@@ -76,8 +77,8 @@ class CdrReader:
         padding = (size - (relative_offset % size)) % size
         self.stream.seek(padding, io.SEEK_CUR)
 
-    def _read_message(self, msg_type: "MessageType"):
-        result = {}
+    def _read_message(self, msg_type: "MessageType") -> SimpleNamespace:
+        result: dict[str, object] = {}
         types = self.types
         read_array = self._read_array
         read_message = self._read_message
@@ -89,7 +90,7 @@ class CdrReader:
                 result[field.name] = read_message(types[field.type])
             else:
                 result[field.name] = read_primitive(field.type, field.enum_type)
-        return result
+        return SimpleNamespace(**result)
 
     def _read_array(self, field):
         # Sequence length is prefixed with UInt32

--- a/mcap_ros2idl_support/decode_factory.py
+++ b/mcap_ros2idl_support/decode_factory.py
@@ -27,7 +27,7 @@ class CdrDecodeFactory(DecoderFactory):
     Instances of this factory can be supplied to
     :py:meth:`mcap.reader.make_reader` so that calls to
     :py:meth:`mcap.reader.McapReader.iter_decoded_messages` will return
-    dictionaries representing ROS 2 messages.
+    :class:`types.SimpleNamespace` objects representing ROS 2 messages.
     """
 
     def __init__(self, schemas: dict[int, SchemaInfo]):

--- a/tests/test_cdr_reader.py
+++ b/tests/test_cdr_reader.py
@@ -1,6 +1,7 @@
 import struct
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 # Insert the parent directory at the start of sys.path to ensure tests
 # use the local (uninstalled) version of the package. This is intentional
@@ -46,7 +47,7 @@ def test_enum_with_uint8():
     enum_map = {"Status": {0: "UNKNOWN", 2: "OK"}}
     reader = CdrReader(type_map, enum_map)
     data = b"\x00\x00\x00\x00" + b"\x02"
-    assert reader.read("Msg", data) == {"status": "OK"}
+    assert reader.read("Msg", data) == SimpleNamespace(status="OK")
 
 
 def test_little_endian_uint32():
@@ -64,7 +65,7 @@ def test_little_endian_uint32():
     }
     reader = CdrReader(type_map)
     data = b"\x00\x01\x00\x00" + struct.pack("<I", 0x01020304)
-    assert reader.read("Msg", data) == {"value": 0x01020304}
+    assert reader.read("Msg", data) == SimpleNamespace(value=0x01020304)
 
 
 def test_big_endian_uint32():
@@ -82,4 +83,4 @@ def test_big_endian_uint32():
     }
     reader = CdrReader(type_map)
     data = b"\x00\x00\x00\x00" + struct.pack(">I", 0x01020304)
-    assert reader.read("Msg", data) == {"value": 0x01020304}
+    assert reader.read("Msg", data) == SimpleNamespace(value=0x01020304)

--- a/tests/test_decode_factory.py
+++ b/tests/test_decode_factory.py
@@ -1,6 +1,5 @@
 import struct
-import sys
-from pathlib import Path
+from types import SimpleNamespace
 
 from mcap.reader import make_reader  # noqa: E402
 from mcap.writer import Writer  # noqa: E402
@@ -35,4 +34,4 @@ def test_decode_factory_integration(tmp_path):
         decoded = list(reader.iter_decoded_messages())
         assert len(decoded) == 1
         _, _, _, msg = decoded[0]
-        assert msg == {"value": 42}
+        assert msg == SimpleNamespace(value=42)


### PR DESCRIPTION
## Summary
- return SimpleNamespace objects from CdrReader to enable dot access
- update decode factory docs, CLI, README and tests accordingly
- remove unnecessary `sys.path` modification from decode factory test

## Testing
- `pre-commit run --files tests/test_decode_factory.py`
- `pytest tests/test_cdr_reader.py tests/test_decode_factory.py`


------
https://chatgpt.com/codex/tasks/task_e_68985319b73883309ee989cb926e21e9