### PR TITLE
Refactor decode factory to lazy Ros2DecodeFactory

### DIFF
--- a/examples/cli.py
+++ b/examples/cli.py
@@ -7,8 +7,7 @@ from argparse import ArgumentParser
 
 from mcap.reader import make_reader
 
-from mcap_ros2idl_support.decode_factory import CdrDecodeFactory
-from mcap_ros2idl_support.idl_loader import load_idl
+from mcap_ros2idl_support import Ros2DecodeFactory
 
 
 def main() -> None:
@@ -30,8 +29,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    schemas = load_idl(args.mcap_file)
-    factory = CdrDecodeFactory(schemas)
+    factory = Ros2DecodeFactory()
 
     with open(args.mcap_file, "rb") as f:
         reader = make_reader(f, decoder_factories=[factory])

--- a/mcap_ros2idl_support/__init__.py
+++ b/mcap_ros2idl_support/__init__.py
@@ -1,5 +1,5 @@
 from .cdr_reader import CdrReader, Field, MessageType
-from .decode_factory import CdrDecodeFactory, make_decoder_factory
+from .decode_factory import Ros2DecodeFactory
 from .idl_loader import SchemaInfo, load_idl
 
 __all__ = [
@@ -8,6 +8,5 @@ __all__ = [
     "CdrReader",
     "SchemaInfo",
     "load_idl",
-    "CdrDecodeFactory",
-    "make_decoder_factory",
+    "Ros2DecodeFactory",
 ]

--- a/mcap_ros2idl_support/decode_factory.py
+++ b/mcap_ros2idl_support/decode_factory.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from typing import Callable, Optional
 
 from mcap.decoder import DecoderFactory
 from mcap.records import Schema
+from ros2idl_parser import parse_ros2idl
+from rosmsg import parse as parse_ros2msg
 
-from .cdr_reader import CdrReader
-from .idl_loader import SchemaInfo
+from .cdr_reader import CdrReader, MessageType
 
 
 def ros2_type_name_from_schema_name(name: str) -> str:
@@ -21,7 +23,7 @@ def ros2_type_name_from_schema_name(name: str) -> str:
     return name.replace("::", "/")
 
 
-class CdrDecodeFactory(DecoderFactory):
+class Ros2DecodeFactory(DecoderFactory):
     """DecodeFactory for CDR-encoded ROS 2 messages.
 
     Instances of this factory can be supplied to
@@ -30,11 +32,35 @@ class CdrDecodeFactory(DecoderFactory):
     dictionaries representing ROS 2 messages.
     """
 
-    def __init__(self, schemas: dict[int, SchemaInfo]):
-        self._readers: dict[int, CdrReader] = {
-            schema_id: CdrReader(info.type_map, info.enum_map)
-            for schema_id, info in schemas.items()
-        }
+    def __init__(self) -> None:
+        self._readers: dict[int, CdrReader] = {}
+
+    def _build_reader(self, schema: Schema) -> Optional[CdrReader]:
+        if schema.encoding == "ros2idl":
+            try:
+                parsed = parse_ros2idl(schema.data.decode("utf-8"))
+            except ValueError as e:
+                print(f"Error parsing ros2idl for schema ID {schema.id}: {e}")
+                return None
+        elif schema.encoding == "ros2msg":
+            parsed = parse_ros2msg(schema.data.decode("utf-8"))
+        else:
+            print(
+                f"Unknown schema encoding: {schema.encoding} for schema ID: {schema.id}"
+            )
+            return None
+
+        type_map: dict[str, MessageType] = {}
+        enum_map: dict[str, dict[int, str]] = {}
+        for type_def in parsed:
+            name = type_def.name or schema.name
+            field_dicts = [asdict(f) for f in type_def.definitions]
+            type_map[name] = MessageType(name, field_dicts)
+            enum_candidates = [f for f in type_def.definitions if f.isConstant]
+            if enum_candidates:
+                enum_lookup = {f.value: f.name for f in enum_candidates}
+                enum_map[name] = enum_lookup
+        return CdrReader(type_map, enum_map)
 
     def decoder_for(
         self, message_encoding: str, schema: Optional[Schema]
@@ -43,23 +69,13 @@ class CdrDecodeFactory(DecoderFactory):
             return None
         reader = self._readers.get(schema.id)
         if reader is None:
-            return None
+            reader = self._build_reader(schema)
+            if reader is None:
+                return None
+            self._readers[schema.id] = reader
         type_name = ros2_type_name_from_schema_name(schema.name)
 
         def decode(data: bytes) -> object:
             return reader.read(type_name, data)
 
         return decode
-
-
-def make_decoder_factory(mcap_file: str) -> CdrDecodeFactory:
-    """Create a :class:`CdrDecodeFactory` from an MCAP file.
-
-    This convenience function parses the schemas embedded in ``mcap_file``
-    using the pure-Python IDL loader and returns a decode factory ready to be
-    supplied to :py:meth:`mcap.reader.make_reader`.
-    """
-    from .idl_loader_py import load_idl as load_idl_py
-
-    schemas = load_idl_py(mcap_file)
-    return CdrDecodeFactory(schemas)

--- a/mcap_ros2idl_support/decode_factory.py
+++ b/mcap_ros2idl_support/decode_factory.py
@@ -40,7 +40,8 @@ class Ros2DecodeFactory(DecoderFactory):
         if schema.encoding == "ros2idl":
             try:
                 parsed = parse_ros2idl(schema.data.decode("utf-8"))
-            except ValueError as e:
+            except AttributeError as e:
+                # When the schema contains union types, the parsing may fail
                 print(f"Error parsing ros2idl for schema ID {schema.id}: {e}")
                 return None
         elif schema.encoding == "ros2msg":

--- a/mcap_ros2idl_support/decode_factory.py
+++ b/mcap_ros2idl_support/decode_factory.py
@@ -34,6 +34,7 @@ class Ros2DecodeFactory(DecoderFactory):
 
     def __init__(self) -> None:
         self._readers: dict[int, CdrReader] = {}
+        self._unsupported_schema_ids: set[int] = set()
 
     def _build_reader(self, schema: Schema) -> Optional[CdrReader]:
         if schema.encoding == "ros2idl":
@@ -67,10 +68,15 @@ class Ros2DecodeFactory(DecoderFactory):
     ) -> Optional[Callable[[bytes], object]]:
         if message_encoding != "cdr" or schema is None:
             return None
+
+        if schema.id in self._unsupported_schema_ids:
+            return None
+
         reader = self._readers.get(schema.id)
         if reader is None:
             reader = self._build_reader(schema)
             if reader is None:
+                self._unsupported_schema_ids.add(schema.id)
                 return None
             self._readers[schema.id] = reader
         type_name = ros2_type_name_from_schema_name(schema.name)

--- a/tests/test_decode_factory.py
+++ b/tests/test_decode_factory.py
@@ -1,6 +1,7 @@
 import struct
 
 from mcap.reader import make_reader
+from mcap.records import Schema
 from mcap.writer import Writer
 
 from mcap_ros2idl_support import Ros2DecodeFactory
@@ -28,3 +29,23 @@ def test_decode_factory_integration(tmp_path):
         assert len(decoded) == 1
         _, _, _, msg = decoded[0]
         assert msg == {"value": 42}
+
+
+def test_decoder_caches_unsupported_schema(monkeypatch):
+    factory = Ros2DecodeFactory()
+    schema_data = b"module example { union U switch(int32){ case 0: int32 a; }; };"
+    schema = Schema(
+        id=1,
+        name="example/U",
+        encoding="ros2idl",
+        data=schema_data,
+    )
+
+    assert factory.decoder_for("cdr", schema) is None
+
+    def fail(*args, **kwargs):  # pragma: no cover - fail if called
+        raise AssertionError("parse_ros2idl called again")
+
+    monkeypatch.setattr("mcap_ros2idl_support.decode_factory.parse_ros2idl", fail)
+
+    assert factory.decoder_for("cdr", schema) is None

--- a/tests/test_decode_factory.py
+++ b/tests/test_decode_factory.py
@@ -3,26 +3,20 @@ import struct
 from mcap.reader import make_reader
 from mcap.writer import Writer
 
-from mcap_ros2idl_support import CdrDecodeFactory, MessageType, SchemaInfo
+from mcap_ros2idl_support import Ros2DecodeFactory
 
 CDR_LE_V1_HEADER = b"\x00\x01\x00\x00"  # CDR little-endian header (version 1)
 
 
 def test_decode_factory_integration(tmp_path):
-    type_map = {
-        "Msg": MessageType(
-            "Msg",
-            [{"name": "value", "type": "uint32", "isComplex": False}],
-        )
-    }
-    info = SchemaInfo(type_map, {})
-    factory = CdrDecodeFactory({1: info})
+    factory = Ros2DecodeFactory()
 
     mcap_path = tmp_path / "test.mcap"
     with open(mcap_path, "wb") as f:
         writer = Writer(f)
         writer.start()
-        schema_id = writer.register_schema("Msg", "ros2msg", b"")
+        schema_data = b"uint32 value\n"
+        schema_id = writer.register_schema("Msg", "ros2msg", schema_data)
         channel_id = writer.register_channel("/test", "cdr", schema_id)
         data = CDR_LE_V1_HEADER + struct.pack("<I", 42)
         writer.add_message(channel_id, 0, data, 0)


### PR DESCRIPTION
## Summary
- rename CdrDecodeFactory to Ros2DecodeFactory
- lazily build CdrReader instances from schema data
- update example and tests to use new factory API

## Testing
- `pre-commit run --files examples/cli.py mcap_ros2idl_support/__init__.py mcap_ros2idl_support/decode_factory.py tests/test_decode_factory.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898c227a78c83308ec1c4a9d96e9aa6