### PR TITLE
chore: pin git dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ authors = [{ name = "dskkato" }]
 dependencies = [
     "lark>=1.2.0",
     "mcap>=1.3.0",
-    "rosmsg @ git+https://github.com/dskkato/ros-typescript.git@main",
-    "omgidl @ git+https://github.com/dskkato/omgidl.git@main",
+    "rosmsg @ git+https://github.com/dskkato/ros-typescript.git@02c44dc1dfda6ebb59aea523e194d0d604c584b9",
+    "omgidl @ git+https://github.com/dskkato/omgidl.git@adc0d0971d45feea155d3177815e0cdf92215779",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- pin `rosmsg` and `omgidl` dependencies to specific commit hashes for stability

## Testing
- `pre-commit run --files pyproject.toml`
- `pip install -e .[dev]` *(fails: ResolutionImpossible due to dependency conflict)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689927fa1b208330ba4dab2e23ada9a6