### PR TITLE
chore: remove direct lark and omgidl dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,8 @@ requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "dskkato" }]
 dependencies = [
-    "lark>=1.2.0",
     "mcap>=1.3.0",
-    "rosmsg @ git+https://github.com/dskkato/ros-typescript.git@main",
-    "omgidl @ git+https://github.com/dskkato/omgidl.git@main",
+    "rosmsg @ git+https://github.com/dskkato/ros-typescript.git@main"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- rely on transitive omgidl and lark dependencies by removing them from project configuration

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68999199061483308add4475e5bc6660