### PR TITLE
Vendor rosmsg and related utilities

### DIFF
--- a/mcap_ros2idl_support/__init__.py
+++ b/mcap_ros2idl_support/__init__.py
@@ -1,6 +1,9 @@
 """Public API for the mcap_ros2idl_support package."""
 
-from rosmsg2_serialization import MessageReader, MessageReaderOptions
+from mcap_ros2idl_support.rosmsg2_serialization import (
+    MessageReader,
+    MessageReaderOptions,
+)
 
 from .decode_factory import Ros2DecodeFactory
 

--- a/mcap_ros2idl_support/cdr/__init__.py
+++ b/mcap_ros2idl_support/cdr/__init__.py
@@ -1,0 +1,42 @@
+"""Python port of the ``cdr`` TypeScript library.
+
+At this stage the port only includes a subset of the original project –
+primarily enumerations and small utility helpers.  The public API mirrors
+``src/index.ts`` of the original repository by re-exporting the
+implemented components.
+"""
+
+from __future__ import annotations
+
+from mcap_ros2idl_support.cdr.encapsulation_kind import EncapsulationKind
+from mcap_ros2idl_support.cdr.get_encapsulation_kind_info import (
+    EncapsulationInfo,
+    get_encapsulation_kind_info,
+)
+from mcap_ros2idl_support.cdr.is_big_endian import is_big_endian
+from mcap_ros2idl_support.cdr.length_codes import (
+    LengthCode,
+    LengthCodeError,
+    get_length_code_for_object_size,
+    length_code_to_object_sizes,
+)
+from mcap_ros2idl_support.cdr.reader import CdrReader
+from mcap_ros2idl_support.cdr.reserved_pids import EXTENDED_PID, SENTINEL_PID
+from mcap_ros2idl_support.cdr.size_calculator import CdrSizeCalculator
+from mcap_ros2idl_support.cdr.writer import CdrWriter
+
+__all__ = [
+    "EncapsulationKind",
+    "EncapsulationInfo",
+    "get_encapsulation_kind_info",
+    "is_big_endian",
+    "LengthCode",
+    "LengthCodeError",
+    "get_length_code_for_object_size",
+    "length_code_to_object_sizes",
+    "CdrReader",
+    "CdrWriter",
+    "CdrSizeCalculator",
+    "EXTENDED_PID",
+    "SENTINEL_PID",
+]

--- a/mcap_ros2idl_support/cdr/encapsulation_kind.py
+++ b/mcap_ros2idl_support/cdr/encapsulation_kind.py
@@ -1,0 +1,46 @@
+"""Enumerations for CDR encapsulation kinds.
+
+This mirrors the constants defined in the TypeScript library's
+``EncapsulationKind`` enum.  The values originate from the
+DDS-XTypes specification and are used to describe how data is
+serialized within a CDR stream.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EncapsulationKind(Enum):
+    """Enumeration of the various CDR encapsulation kinds.
+
+    The member values match those used by the TypeScript implementation
+    and the DDS-XTypes specification.  ``Enum`` is used instead of
+    :class:`~enum.IntEnum` to provide a closer analogue to TypeScript's
+    ``enum`` semantics; code that requires the numerical value should use
+    the :attr:`value` attribute of each member.
+    """
+
+    # Plain CDR encodings
+    CDR_BE = 0x00  # Plain CDR, big-endian
+    CDR_LE = 0x01  # Plain CDR, little-endian
+
+    # Parameter list CDR encodings (XCDR1)
+    PL_CDR_BE = 0x02  # Parameter List CDR, big-endian
+    PL_CDR_LE = 0x03  # Parameter List CDR, little-endian
+
+    # XCDR2 encodings
+    CDR2_BE = 0x10  # Plain CDR2, big-endian
+    CDR2_LE = 0x11  # Plain CDR2, little-endian
+    PL_CDR2_BE = 0x12  # Parameter List CDR2, big-endian
+    PL_CDR2_LE = 0x13  # Parameter List CDR2, little-endian
+    DELIMITED_CDR2_BE = 0x14  # Delimited CDR2, big-endian
+    DELIMITED_CDR2_LE = 0x15  # Delimited CDR2, little-endian
+
+    # RTPS specific IDs for XCDR2
+    RTPS_CDR2_BE = 0x06  # Plain CDR2, big-endian
+    RTPS_CDR2_LE = 0x07  # Plain CDR2, little-endian
+    RTPS_DELIMITED_CDR2_BE = 0x08  # Delimited CDR2, big-endian
+    RTPS_DELIMITED_CDR2_LE = 0x09  # Delimited CDR2, little-endian
+    RTPS_PL_CDR2_BE = 0x0A  # Parameter List CDR2, big-endian
+    RTPS_PL_CDR2_LE = 0x0B  # Parameter List CDR2, little-endian

--- a/mcap_ros2idl_support/cdr/get_encapsulation_kind_info.py
+++ b/mcap_ros2idl_support/cdr/get_encapsulation_kind_info.py
@@ -1,0 +1,82 @@
+"""Utility helpers for :class:`~cdr.encapsulation_kind.EncapsulationKind`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mcap_ros2idl_support.cdr.encapsulation_kind import EncapsulationKind
+
+
+@dataclass(frozen=True)
+class EncapsulationInfo:
+    """Information about the behaviour of an :class:`EncapsulationKind`.
+
+    Attributes correspond to the flags described in the TypeScript
+    implementation.  They are primarily used by the reader and writer to
+    determine how a payload should be serialised or parsed.
+    """
+
+    is_cdr2: bool
+    little_endian: bool
+    uses_delimiter_header: bool
+    uses_member_header: bool
+
+
+def get_encapsulation_kind_info(kind: EncapsulationKind) -> EncapsulationInfo:
+    """Return information about a given ``EncapsulationKind``.
+
+    Parameters
+    ----------
+    kind:
+        The :class:`EncapsulationKind` to inspect.
+
+    Returns
+    -------
+    EncapsulationInfo
+        A data object describing whether the kind is CDR2, little endian
+        and whether it uses delimiter or member headers.
+    """
+
+    # ``Enum`` members do not support ordering comparisons directly, so we
+    # compare using their underlying integer values.
+    is_cdr2 = kind.value > EncapsulationKind.PL_CDR_LE.value
+
+    little_endian = kind in {
+        EncapsulationKind.CDR_LE,
+        EncapsulationKind.PL_CDR_LE,
+        EncapsulationKind.CDR2_LE,
+        EncapsulationKind.PL_CDR2_LE,
+        EncapsulationKind.DELIMITED_CDR2_LE,
+        EncapsulationKind.RTPS_CDR2_LE,
+        EncapsulationKind.RTPS_PL_CDR2_LE,
+        EncapsulationKind.RTPS_DELIMITED_CDR2_LE,
+    }
+
+    is_delimited_cdr2 = kind in {
+        EncapsulationKind.DELIMITED_CDR2_BE,
+        EncapsulationKind.DELIMITED_CDR2_LE,
+        EncapsulationKind.RTPS_DELIMITED_CDR2_BE,
+        EncapsulationKind.RTPS_DELIMITED_CDR2_LE,
+    }
+
+    is_pl_cdr2 = kind in {
+        EncapsulationKind.PL_CDR2_BE,
+        EncapsulationKind.PL_CDR2_LE,
+        EncapsulationKind.RTPS_PL_CDR2_BE,
+        EncapsulationKind.RTPS_PL_CDR2_LE,
+    }
+
+    is_pl_cdr1 = kind in {
+        EncapsulationKind.PL_CDR_BE,
+        EncapsulationKind.PL_CDR_LE,
+    }
+
+    uses_delimiter_header = is_delimited_cdr2 or is_pl_cdr2
+    uses_member_header = is_pl_cdr2 or is_pl_cdr1
+
+    return EncapsulationInfo(
+        is_cdr2=is_cdr2,
+        little_endian=little_endian,
+        uses_delimiter_header=uses_delimiter_header,
+        uses_member_header=uses_member_header,
+    )

--- a/mcap_ros2idl_support/cdr/is_big_endian.py
+++ b/mcap_ros2idl_support/cdr/is_big_endian.py
@@ -1,0 +1,16 @@
+"""Helpers for determining system endianness."""
+
+from __future__ import annotations
+
+import sys
+
+
+def is_big_endian() -> bool:
+    """Return ``True`` if the current system uses big-endian byte order.
+
+    The TypeScript implementation inspects an ``ArrayBuffer`` to determine
+    endianness.  In Python we can rely on :mod:`sys` which exposes the
+    interpreter's byte order via :data:`sys.byteorder`.
+    """
+
+    return sys.byteorder == "big"

--- a/mcap_ros2idl_support/cdr/length_codes.py
+++ b/mcap_ros2idl_support/cdr/length_codes.py
@@ -1,0 +1,56 @@
+"""Helpers for working with XCDR length codes."""
+
+from __future__ import annotations
+
+from typing import Dict, Literal
+
+LengthCode = Literal[0, 1, 2, 3, 4, 5, 6, 7]
+
+
+class LengthCodeError(ValueError):
+    """Raised when an object size cannot be represented by a length code."""
+
+
+_DEF_SIZES: Dict[int, LengthCode] = {1: 0, 2: 1, 4: 2, 8: 3}
+
+
+def get_length_code_for_object_size(object_size: int) -> LengthCode:
+    """Return the default length code for ``object_size``.
+
+    Parameters
+    ----------
+    object_size:
+        Size in bytes of the value to encode.
+
+    Returns
+    -------
+    LengthCode
+        The length code corresponding to ``object_size``.
+
+    Raises
+    ------
+    LengthCodeError
+        If ``object_size`` is larger than ``0xffffffff`` without an explicit
+        length code.  This mirrors the behaviour of the TypeScript
+        implementation.
+    """
+
+    if object_size in _DEF_SIZES:
+        return _DEF_SIZES[object_size]
+
+    if object_size > 0xFFFFFFFF:
+        raise LengthCodeError(
+            "Object size %d for EMHEADER too large without specifying length code. "
+            "Max size is %d" % (object_size, 0xFFFFFFFF)
+        )
+
+    # For any other size up to the maximum, a length code of 4 is used.
+    return 4
+
+
+length_code_to_object_sizes: Dict[LengthCode, int] = {
+    0: 1,
+    1: 2,
+    2: 4,
+    3: 8,
+}

--- a/mcap_ros2idl_support/cdr/reader.py
+++ b/mcap_ros2idl_support/cdr/reader.py
@@ -1,0 +1,457 @@
+"""Implementation of a binary CDR reader.
+
+This module provides a Python port of a subset of the original TypeScript
+``CdrReader``.  It supports reading primitive values, strings and arrays from a
+byte buffer while honouring the alignment and endianness rules defined by the
+CDR specification.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import Any, Sequence, cast
+
+from mcap_ros2idl_support.cdr.encapsulation_kind import EncapsulationKind
+from mcap_ros2idl_support.cdr.get_encapsulation_kind_info import (
+    get_encapsulation_kind_info,
+)
+from mcap_ros2idl_support.cdr.is_big_endian import is_big_endian
+from mcap_ros2idl_support.cdr.length_codes import (
+    LengthCode,
+    length_code_to_object_sizes,
+)
+from mcap_ros2idl_support.cdr.reserved_pids import EXTENDED_PID, SENTINEL_PID
+
+# Precompiled ``struct`` format objects to avoid repeatedly parsing the
+# same format strings.  ``struct.Struct`` instances are considerably faster
+# when used many times as they cache the parsing of the format.
+_INT8 = struct.Struct("b")
+_UINT8 = struct.Struct("B")
+_INT16_LE = struct.Struct("<h")
+_INT16_BE = struct.Struct(">h")
+_UINT16_LE = struct.Struct("<H")
+_UINT16_BE = struct.Struct(">H")
+_INT32_LE = struct.Struct("<i")
+_INT32_BE = struct.Struct(">i")
+_UINT32_LE = struct.Struct("<I")
+_UINT32_BE = struct.Struct(">I")
+_INT64_LE = struct.Struct("<q")
+_INT64_BE = struct.Struct(">q")
+_UINT64_LE = struct.Struct("<Q")
+_UINT64_BE = struct.Struct(">Q")
+_FLOAT32_LE = struct.Struct("<f")
+_FLOAT32_BE = struct.Struct(">f")
+_FLOAT64_LE = struct.Struct("<d")
+_FLOAT64_BE = struct.Struct(">d")
+
+# Mapping from format character to item size.  Using a dictionary avoids the
+# overhead of calling :func:`struct.calcsize` repeatedly when decoding arrays.
+_ITEMSIZE = {
+    "b": 1,
+    "B": 1,
+    "h": 2,
+    "H": 2,
+    "i": 4,
+    "I": 4,
+    "q": 8,
+    "Q": 8,
+    "f": 4,
+    "d": 8,
+}
+
+
+@dataclass
+class MemberHeader:
+    """Representation of a member header read from the stream."""
+
+    id: int
+    object_size: int
+    must_understand: bool
+    length_code: LengthCode | None = None
+    read_sentinel_header: bool | None = None
+
+
+class CdrReader:
+    """Read primitive values and arrays from a CDR encoded byte buffer."""
+
+    def __init__(self, data: bytes | bytearray | memoryview) -> None:
+        if isinstance(data, memoryview):
+            self._view = data
+        else:
+            self._view = memoryview(data)
+
+        if self._view.nbytes < 4:
+            raise ValueError(
+                f"Invalid CDR data size {self._view.nbytes}, "
+                "must contain at least a 4-byte header",
+            )
+
+        # Encapsulation kind is encoded in the second byte of the header.
+        kind = EncapsulationKind(self._view[1])
+        info = get_encapsulation_kind_info(kind)
+
+        self.little_endian = info.little_endian
+        self.host_little_endian = not is_big_endian()
+        self.is_cdr2 = info.is_cdr2
+        self.eight_byte_alignment = 4 if self.is_cdr2 else 8
+        self.uses_delimiter_header = info.uses_delimiter_header
+        self.uses_member_header = info.uses_member_header
+
+        # Pre-select struct objects and prefix based on endianness so that
+        # primitive readers avoid branching and repeated format parsing.
+        if self.little_endian:
+            self._int16_struct = _INT16_LE
+            self._uint16_struct = _UINT16_LE
+            self._int32_struct = _INT32_LE
+            self._uint32_struct = _UINT32_LE
+            self._int64_struct = _INT64_LE
+            self._uint64_struct = _UINT64_LE
+            self._float32_struct = _FLOAT32_LE
+            self._float64_struct = _FLOAT64_LE
+            self._endian_prefix = "<"
+        else:
+            self._int16_struct = _INT16_BE
+            self._uint16_struct = _UINT16_BE
+            self._int32_struct = _INT32_BE
+            self._uint32_struct = _UINT32_BE
+            self._int64_struct = _INT64_BE
+            self._uint64_struct = _UINT64_BE
+            self._float32_struct = _FLOAT32_BE
+            self._float64_struct = _FLOAT64_BE
+            self._endian_prefix = ">"
+
+        # Origin and current offset start immediately after the four byte header
+        self.origin = 4
+        self.offset = 4
+
+    # ------------------------------------------------------------------
+    # Basic properties
+    # ------------------------------------------------------------------
+    @property
+    def kind(self) -> EncapsulationKind:
+        return EncapsulationKind(self._view[1])
+
+    @property
+    def decoded_bytes(self) -> int:
+        return self.offset
+
+    @property
+    def byte_length(self) -> int:
+        return self._view.nbytes
+
+    # ------------------------------------------------------------------
+    # Primitive readers
+    # ------------------------------------------------------------------
+    def int8(self) -> int:
+        value = _INT8.unpack_from(self._view, self.offset)[0]
+        self.offset += 1
+        return value
+
+    def uint8(self) -> int:
+        value = _UINT8.unpack_from(self._view, self.offset)[0]
+        self.offset += 1
+        return value
+
+    def int16(self) -> int:
+        self.align(2)
+        value = self._int16_struct.unpack_from(self._view, self.offset)[0]
+        self.offset += 2
+        return value
+
+    def uint16(self) -> int:
+        self.align(2)
+        value = self._uint16_struct.unpack_from(self._view, self.offset)[0]
+        self.offset += 2
+        return value
+
+    def int32(self) -> int:
+        self.align(4)
+        value = self._int32_struct.unpack_from(self._view, self.offset)[0]
+        self.offset += 4
+        return value
+
+    def uint32(self) -> int:
+        self.align(4)
+        value = self._uint32_struct.unpack_from(self._view, self.offset)[0]
+        self.offset += 4
+        return value
+
+    def int64(self) -> int:
+        self.align(self.eight_byte_alignment)
+        value = self._int64_struct.unpack_from(self._view, self.offset)[0]
+        self.offset += 8
+        return value
+
+    def uint64(self) -> int:
+        self.align(self.eight_byte_alignment)
+        value = self._uint64_struct.unpack_from(self._view, self.offset)[0]
+        self.offset += 8
+        return value
+
+    def uint16_be(self) -> int:
+        self.align(2)
+        value = _UINT16_BE.unpack_from(self._view, self.offset)[0]
+        self.offset += 2
+        return value
+
+    def uint32_be(self) -> int:
+        self.align(4)
+        value = _UINT32_BE.unpack_from(self._view, self.offset)[0]
+        self.offset += 4
+        return value
+
+    def uint64_be(self) -> int:
+        self.align(self.eight_byte_alignment)
+        value = _UINT64_BE.unpack_from(self._view, self.offset)[0]
+        self.offset += 8
+        return value
+
+    def float32(self) -> float:
+        self.align(4)
+        value = self._float32_struct.unpack_from(self._view, self.offset)[0]
+        self.offset += 4
+        return value
+
+    def float64(self) -> float:
+        self.align(self.eight_byte_alignment)
+        value = self._float64_struct.unpack_from(self._view, self.offset)[0]
+        self.offset += 8
+        return value
+
+    # ------------------------------------------------------------------
+    # String and headers
+    # ------------------------------------------------------------------
+    def string(self, preread_length: int | None = None) -> str:
+        length = preread_length or self.uint32()
+        if length <= 1:
+            self.offset += length
+            return ""
+
+        data = self._view[self.offset : self.offset + length - 1]
+        value = data.tobytes().decode("utf-8")
+        self.offset += length
+        return value
+
+    def d_header(self) -> int:
+        """Read the delimiter header and return the object size."""
+
+        return self.uint32()
+
+    # ------------------------------------------------------------------
+    # EMHEADER reading (used by XCDR2)
+    # ------------------------------------------------------------------
+    def em_header(self) -> MemberHeader:
+        return self._member_header_v2() if self.is_cdr2 else self._member_header_v1()
+
+    def _member_header_v1(self) -> MemberHeader:
+        # XCDR1 PL_CDR encapsulation parameter header
+        self.align(4)
+        id_header = self.uint16()
+
+        must_understand = ((id_header & 0x4000) >> 14) == 1
+        implementation_specific = ((id_header & 0x8000) >> 15) == 1
+        extended_pid = (id_header & 0x3FFF) == EXTENDED_PID
+        sentinel_pid = (id_header & 0x3FFF) == SENTINEL_PID
+
+        if sentinel_pid:
+            return MemberHeader(
+                id=SENTINEL_PID,
+                object_size=0,
+                must_understand=False,
+                read_sentinel_header=True,
+            )
+
+        uses_reserved_pid = (id_header & 0x3FFF) > SENTINEL_PID
+        if uses_reserved_pid or implementation_specific:
+            raise ValueError(f"Unsupported parameter ID header {id_header:04x}")
+
+        if extended_pid:
+            # consume remaining part of the header
+            self.uint16()
+
+        pid = self.uint32() if extended_pid else id_header & 0x3FFF
+        object_size = self.uint32() if extended_pid else self.uint16()
+        self._reset_origin()
+        return MemberHeader(
+            id=pid,
+            object_size=object_size,
+            must_understand=must_understand,
+        )
+
+    def _member_header_v2(self) -> MemberHeader:
+        header = self.uint32()
+        must_understand = ((header & 0x80000000) >> 31) == 1
+        length_code = cast(LengthCode, ((header & 0x70000000) >> 28) & 0x7)
+        pid = header & 0x0FFFFFFF
+        object_size = self._em_header_object_size(length_code)
+        return MemberHeader(
+            id=pid,
+            object_size=object_size,
+            must_understand=must_understand,
+            length_code=length_code,
+        )
+
+    def _em_header_object_size(self, length_code: LengthCode) -> int:
+        match length_code:
+            case 0 | 1 | 2 | 3:
+                return length_code_to_object_sizes[length_code]
+            case 4 | 5:
+                return self.uint32()
+            case 6:
+                return 4 * self.uint32()
+            case 7:
+                return 8 * self.uint32()
+            case _:
+                raise ValueError(
+                    f"Invalid length code {length_code} in EMHEADER "
+                    f"at offset {self.offset - 4}",
+                )
+
+    def _reset_origin(self) -> None:
+        self.origin = self.offset
+
+    def sentinel_header(self) -> None:
+        """Read the PID_SENTINEL value if encapsulation supports it."""
+
+        if not self.is_cdr2:
+            self.align(4)
+            header = self.uint16()
+            sentinel_pid_flag = (header & 0x3FFF) == SENTINEL_PID
+            if not sentinel_pid_flag:
+                raise ValueError(
+                    f"Expected SENTINEL_PID ({SENTINEL_PID:04x}) flag, "
+                    f"but got {header:04x}",
+                )
+            self.uint16()
+
+    # ------------------------------------------------------------------
+    # Sequence helpers and array readers
+    # ------------------------------------------------------------------
+    def sequence_length(self) -> int:
+        return self.uint32()
+
+    # Array readers return a zero-copy ``memoryview`` when possible and fall back
+    # to a Python ``list`` for incompatible cases (misalignment or mismatched
+    # endianness).
+    def int8_array(self, count: int | None = None) -> Sequence[int]:
+        count = self.sequence_length() if count is None else count
+        return cast("Sequence[int]", self._array("b", count, 1))
+
+    def uint8_array(self, count: int | None = None) -> Sequence[int]:
+        count = self.sequence_length() if count is None else count
+        return cast("Sequence[int]", self._array("B", count, 1))
+
+    def _array(
+        self, fmt: str, count: int, alignment: int
+    ) -> Sequence[int] | Sequence[float]:
+        if count == 0:
+            data = self._view[self.offset : self.offset]
+            if self.little_endian == self.host_little_endian:
+                return data.cast(cast(Any, fmt))
+            return []
+
+        self.align(alignment)
+        size = _ITEMSIZE.get(fmt)
+        if size is None:
+            size = struct.calcsize(fmt)
+        start = self.offset
+        end = start + size * count
+        data = self._view[start:end]
+        self.offset = end
+
+        if (
+            self.little_endian == self.host_little_endian
+            and (start - self.origin) % alignment == 0
+        ):
+            return data.cast(cast(Any, fmt))
+
+        if size == 1:
+            return list(data.cast(cast(Any, fmt)))
+
+        values = struct.unpack(f"{self._endian_prefix}{count}{fmt}", data.tobytes())
+        return list(values)
+
+    def int16_array(self, count: int | None = None) -> Sequence[int]:
+        count = self.sequence_length() if count is None else count
+        return cast("Sequence[int]", self._array("h", count, 2))
+
+    def uint16_array(self, count: int | None = None) -> Sequence[int]:
+        count = self.sequence_length() if count is None else count
+        return cast("Sequence[int]", self._array("H", count, 2))
+
+    def int32_array(self, count: int | None = None) -> Sequence[int]:
+        count = self.sequence_length() if count is None else count
+        return cast("Sequence[int]", self._array("i", count, 4))
+
+    def uint32_array(self, count: int | None = None) -> Sequence[int]:
+        count = self.sequence_length() if count is None else count
+        return cast("Sequence[int]", self._array("I", count, 4))
+
+    def int64_array(self, count: int | None = None) -> Sequence[int]:
+        count = self.sequence_length() if count is None else count
+        return cast("Sequence[int]", self._array("q", count, self.eight_byte_alignment))
+
+    def uint64_array(self, count: int | None = None) -> Sequence[int]:
+        count = self.sequence_length() if count is None else count
+        return cast("Sequence[int]", self._array("Q", count, self.eight_byte_alignment))
+
+    def float32_array(self, count: int | None = None) -> Sequence[float]:
+        count = self.sequence_length() if count is None else count
+        return cast("Sequence[float]", self._array("f", count, 4))
+
+    def float64_array(self, count: int | None = None) -> Sequence[float]:
+        count = self.sequence_length() if count is None else count
+        return cast(
+            "Sequence[float]",
+            self._array("d", count, self.eight_byte_alignment),
+        )
+
+    def string_array(self, count: int | None = None) -> list[str]:
+        count = self.sequence_length() if count is None else count
+        if count == 0:
+            return []
+        return [self.string() for _ in range(count)]
+
+    # ------------------------------------------------------------------
+    # Position helpers
+    # ------------------------------------------------------------------
+    def seek(self, relative_offset: int) -> None:
+        new_offset = self.offset + relative_offset
+        if new_offset < 4 or new_offset >= self._view.nbytes:
+            raise ValueError(
+                f"seek({relative_offset}) failed, "
+                f"{new_offset} is outside the data range",
+            )
+        self.offset = new_offset
+
+    def seek_to(self, offset: int) -> None:
+        if offset < 4 or offset >= self._view.nbytes:
+            raise ValueError(
+                f"seekTo({offset}) failed, value is outside the data range"
+            )
+        self.offset = offset
+
+    def clone(self) -> CdrReader:
+        clone = CdrReader(self._view)
+        clone.offset = self.offset
+        clone.origin = self.origin
+        return clone
+
+    def limit(self, length: int) -> None:
+        new_byte_length = self.offset + length
+        if new_byte_length <= self._view.nbytes:
+            self._view = self._view[:new_byte_length]
+        else:
+            raise ValueError(f"length {length} exceeds byte length of view")
+
+    def is_at_end(self) -> bool:
+        return self.offset >= self._view.nbytes
+
+    # ------------------------------------------------------------------
+    # Alignment helper
+    # ------------------------------------------------------------------
+    def align(self, size: int) -> None:
+        alignment = (self.offset - self.origin) % size
+        if alignment > 0:
+            self.offset += size - alignment

--- a/mcap_ros2idl_support/cdr/reserved_pids.py
+++ b/mcap_ros2idl_support/cdr/reserved_pids.py
@@ -1,0 +1,6 @@
+"""Constants for reserved parameter IDs used in XCDR."""
+
+from __future__ import annotations
+
+EXTENDED_PID = 0x3F01
+SENTINEL_PID = 0x3F02

--- a/mcap_ros2idl_support/cdr/size_calculator.py
+++ b/mcap_ros2idl_support/cdr/size_calculator.py
@@ -1,0 +1,90 @@
+"""Utility for computing CDR encoded message sizes.
+
+This module provides a Python translation of the :code:`CdrSizeCalculator`
+class from the original TypeScript implementation.  The calculator tracks an
+internal offset which represents the number of bytes that would be written
+when serialising values in CDR (Common Data Representation) format.  Each
+method returns the new offset after accounting for padding and the size of the
+written value.
+"""
+
+from __future__ import annotations
+
+
+class CdrSizeCalculator:
+    """Compute the number of bytes required for CDR serialisation."""
+
+    # Two bytes for Representation Id and two bytes for Options
+    def __init__(self) -> None:
+        self._offset = 4
+
+    @property
+    def size(self) -> int:
+        """Return the current offset in bytes."""
+
+        return self._offset
+
+    # Basic integer and floating point types ---------------------------------
+    def int8(self) -> int:
+        return self._increment_and_return(1)
+
+    def uint8(self) -> int:
+        return self._increment_and_return(1)
+
+    def int16(self) -> int:
+        return self._increment_and_return(2)
+
+    def uint16(self) -> int:
+        return self._increment_and_return(2)
+
+    def int32(self) -> int:
+        return self._increment_and_return(4)
+
+    def uint32(self) -> int:
+        return self._increment_and_return(4)
+
+    def int64(self) -> int:
+        return self._increment_and_return(8)
+
+    def uint64(self) -> int:
+        return self._increment_and_return(8)
+
+    def float32(self) -> int:
+        return self._increment_and_return(4)
+
+    def float64(self) -> int:
+        return self._increment_and_return(8)
+
+    # Complex types -----------------------------------------------------------
+    def string(self, length: int) -> int:
+        """Account for a UTF-8 string of ``length`` characters.
+
+        The string is prefixed by a 32-bit unsigned length field and suffixed
+        by a null terminator.  The length parameter should reflect the number
+        of bytes in the string *without* the terminator.
+        """
+
+        self.uint32()  # Encoded string length
+        self._offset += length + 1  # Include null terminator
+        return self._offset
+
+    def sequence_length(self) -> int:
+        """Account for the length field of a sequence."""
+
+        return self.uint32()
+
+    # Private helpers --------------------------------------------------------
+    def _increment_and_return(self, byte_count: int) -> int:
+        """Increment the offset by ``byte_count`` and any required padding.
+
+        The CDR encoding requires that primitive types be aligned to their
+        natural boundaries relative to the start of the CDR stream.  The stream
+        begins with a four byte header, so alignment is performed on
+        ``self._offset - 4``.
+        """
+
+        alignment = (self._offset - 4) % byte_count
+        if alignment > 0:
+            self._offset += byte_count - alignment
+        self._offset += byte_count
+        return self._offset

--- a/mcap_ros2idl_support/cdr/writer.py
+++ b/mcap_ros2idl_support/cdr/writer.py
@@ -1,0 +1,685 @@
+"""CDR writer implementation.
+
+This module ports the TypeScript ``CdrWriter`` to Python.  A mutable
+``bytearray`` acts as the backing buffer and numerical values are written
+using :func:`struct.pack_into`.  Only the parts of the original class used
+elsewhere in the project are implemented.
+"""
+
+from __future__ import annotations
+
+import struct
+from array import array as Array
+from typing import Sequence, cast
+
+try:  # Python 3.12+
+    from collections.abc import Buffer
+except ImportError:  # Python <3.12
+    from typing_extensions import Buffer
+
+from mcap_ros2idl_support.cdr.encapsulation_kind import EncapsulationKind
+from mcap_ros2idl_support.cdr.get_encapsulation_kind_info import (
+    get_encapsulation_kind_info,
+)
+from mcap_ros2idl_support.cdr.is_big_endian import is_big_endian
+from mcap_ros2idl_support.cdr.length_codes import (
+    LengthCode,
+    get_length_code_for_object_size,
+    length_code_to_object_sizes,
+)
+from mcap_ros2idl_support.cdr.reserved_pids import EXTENDED_PID, SENTINEL_PID
+
+
+class CdrWriter:
+    """Serialise primitive values into a CDR formatted byte stream."""
+
+    DEFAULT_CAPACITY = 16
+    _ITEMSIZE = {
+        "h": 2,
+        "H": 2,
+        "i": 4,
+        "I": 4,
+        "q": 8,
+        "Q": 8,
+        "f": 4,
+        "d": 8,
+    }
+
+    def __init__(
+        self,
+        *,
+        buffer: bytearray | bytes | None = None,
+        size: int | None = None,
+        kind: EncapsulationKind = EncapsulationKind.CDR_LE,
+    ) -> None:
+        if buffer is not None:
+            self._buffer = bytearray(buffer)
+        elif size is not None:
+            self._buffer = bytearray(size)
+        else:
+            self._buffer = bytearray(self.DEFAULT_CAPACITY)
+
+        info = get_encapsulation_kind_info(kind)
+        self._little_endian = info.little_endian
+        self._host_little_endian = not is_big_endian()
+        self._is_cdr2 = info.is_cdr2
+        self._eight_byte_alignment = 4 if self._is_cdr2 else 8
+
+        self._offset = 0
+        self._origin = 0
+
+        # Representation identifier and options field
+        self._resize_if_needed(4)
+        self._buffer[0] = 0
+        self._buffer[1] = kind.value
+        struct.pack_into(">H", self._buffer, 2, 0)
+        self._offset = 4
+        self._origin = 4
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+    @property
+    def data(self) -> bytes:
+        """Return the written portion of the buffer."""
+
+        return bytes(self._buffer[: self._offset])
+
+    @property
+    def size(self) -> int:
+        """Current size of the written data."""
+
+        return self._offset
+
+    @property
+    def kind(self) -> EncapsulationKind:
+        """Encapsulation kind used by this writer."""
+
+        return EncapsulationKind(self._buffer[1])
+
+    # ------------------------------------------------------------------
+    # Primitive writers
+    # ------------------------------------------------------------------
+    def int8(self, value: int) -> CdrWriter:
+        self._resize_if_needed(1)
+        struct.pack_into("b", self._buffer, self._offset, value)
+        self._offset += 1
+        return self
+
+    def uint8(self, value: int) -> CdrWriter:
+        self._resize_if_needed(1)
+        struct.pack_into("B", self._buffer, self._offset, value)
+        self._offset += 1
+        return self
+
+    def int16(self, value: int) -> CdrWriter:
+        self.align(2)
+        struct.pack_into(self._endian_fmt("h"), self._buffer, self._offset, value)
+        self._offset += 2
+        return self
+
+    def uint16(self, value: int) -> CdrWriter:
+        self.align(2)
+        struct.pack_into(self._endian_fmt("H"), self._buffer, self._offset, value)
+        self._offset += 2
+        return self
+
+    def int32(self, value: int) -> CdrWriter:
+        self.align(4)
+        struct.pack_into(self._endian_fmt("i"), self._buffer, self._offset, value)
+        self._offset += 4
+        return self
+
+    def uint32(self, value: int) -> CdrWriter:
+        self.align(4)
+        struct.pack_into(self._endian_fmt("I"), self._buffer, self._offset, value)
+        self._offset += 4
+        return self
+
+    def int64(self, value: int) -> CdrWriter:
+        self.align(self._eight_byte_alignment, 8)
+        struct.pack_into(self._endian_fmt("q"), self._buffer, self._offset, int(value))
+        self._offset += 8
+        return self
+
+    def uint64(self, value: int) -> CdrWriter:
+        self.align(self._eight_byte_alignment, 8)
+        struct.pack_into(self._endian_fmt("Q"), self._buffer, self._offset, int(value))
+        self._offset += 8
+        return self
+
+    def uint16BE(self, value: int) -> CdrWriter:
+        self.align(2)
+        struct.pack_into(">H", self._buffer, self._offset, value)
+        self._offset += 2
+        return self
+
+    def uint32BE(self, value: int) -> CdrWriter:
+        self.align(4)
+        struct.pack_into(">I", self._buffer, self._offset, value)
+        self._offset += 4
+        return self
+
+    def uint64BE(self, value: int) -> CdrWriter:
+        self.align(self._eight_byte_alignment, 8)
+        struct.pack_into(">Q", self._buffer, self._offset, int(value))
+        self._offset += 8
+        return self
+
+    def float32(self, value: float) -> CdrWriter:
+        self.align(4)
+        struct.pack_into(self._endian_fmt("f"), self._buffer, self._offset, value)
+        self._offset += 4
+        return self
+
+    def float64(self, value: float) -> CdrWriter:
+        self.align(self._eight_byte_alignment, 8)
+        struct.pack_into(self._endian_fmt("d"), self._buffer, self._offset, value)
+        self._offset += 8
+        return self
+
+    # ------------------------------------------------------------------
+    # Helper writers
+    # ------------------------------------------------------------------
+    def string(self, value: str, writeLength: bool = True) -> CdrWriter:
+        data = value.encode("utf-8")
+        if writeLength:
+            self.uint32(len(data) + 1)
+        self._resize_if_needed(len(data) + 1)
+        self._buffer[self._offset : self._offset + len(data)] = data
+        self._buffer[self._offset + len(data)] = 0
+        self._offset += len(data) + 1
+        return self
+
+    def dHeader(self, objectSize: int) -> CdrWriter:
+        """Write a delimiter header using ``objectSize``."""
+
+        return self.uint32(objectSize)
+
+    def emHeader(
+        self,
+        mustUnderstand: bool,
+        id: int,
+        objectSize: int,
+        lengthCode: LengthCode | None = None,
+    ) -> CdrWriter:
+        if self._is_cdr2:
+            return self._member_header_v2(mustUnderstand, id, objectSize, lengthCode)
+        return self._member_header_v1(mustUnderstand, id, objectSize)
+
+    def sentinelHeader(self) -> CdrWriter:
+        if not self._is_cdr2:
+            self.align(4)
+            self.uint16(SENTINEL_PID)
+            self.uint16(0)
+        return self
+
+    def sequenceLength(self, value: int) -> CdrWriter:
+        return self.uint32(value)
+
+    # ------------------------------------------------------------------
+    # Array writers with bulk copy optimisations
+    # ------------------------------------------------------------------
+    def int8Array(
+        self,
+        value: Sequence[int] | bytes | bytearray | Array,
+        writeLength: bool | None = False,
+    ) -> CdrWriter:
+        if writeLength:
+            self.sequenceLength(len(value))
+        if isinstance(value, (bytes, bytearray)):
+            self._resize_if_needed(len(value))
+            self._buffer[self._offset : self._offset + len(value)] = memoryview(value)
+            self._offset += len(value)
+        elif isinstance(value, Array) and value.typecode in ("b", "B"):
+            n = len(value)
+            self._resize_if_needed(n)
+            mv = memoryview(value).cast("B")
+            self._buffer[self._offset : self._offset + n] = mv
+            self._offset += n
+        else:
+            for entry in value:
+                self.int8(entry)
+        return self
+
+    def uint8Array(
+        self,
+        value: Sequence[int] | bytes | bytearray | Array,
+        writeLength: bool | None = False,
+    ) -> CdrWriter:
+        if writeLength:
+            self.sequenceLength(len(value))
+        if isinstance(value, (bytes, bytearray)):
+            self._resize_if_needed(len(value))
+            self._buffer[self._offset : self._offset + len(value)] = memoryview(value)
+            self._offset += len(value)
+        elif isinstance(value, Array) and value.typecode in ("b", "B"):
+            n = len(value)
+            self._resize_if_needed(n)
+            mv = memoryview(value).cast("B")
+            self._buffer[self._offset : self._offset + n] = mv
+            self._offset += n
+        else:
+            for entry in value:
+                self.uint8(entry)
+        return self
+
+    def int16Array(
+        self,
+        value: Sequence[int] | bytes | bytearray | Array,
+        writeLength: bool | None = False,
+    ) -> CdrWriter:
+        if isinstance(value, (bytes, bytearray)):
+            if writeLength:
+                self.sequenceLength(len(value) // 2)
+            self.align(2, len(value))
+            self._resize_if_needed(len(value))
+            self._buffer[self._offset : self._offset + len(value)] = memoryview(value)
+            self._offset += len(value)
+            return self
+        if self._try_write_contiguous(value, "h", 2, writeLength):
+            return self
+        if isinstance(value, Array) and value.typecode == "h":
+            n = len(value)
+            if writeLength:
+                self.sequenceLength(n)
+            self.align(2, n * 2)
+            self._resize_if_needed(n * 2)
+            struct.pack_into(
+                self._endian_fmt(f"{n}h"), self._buffer, self._offset, *value
+            )
+            self._offset += n * 2
+            return self
+        if writeLength:
+            self.sequenceLength(len(value))
+        for entry in value:
+            self.int16(entry)
+        return self
+
+    def uint16Array(
+        self,
+        value: Sequence[int] | bytes | bytearray | Array,
+        writeLength: bool | None = False,
+    ) -> CdrWriter:
+        if isinstance(value, (bytes, bytearray)):
+            if writeLength:
+                self.sequenceLength(len(value) // 2)
+            self.align(2, len(value))
+            self._resize_if_needed(len(value))
+            self._buffer[self._offset : self._offset + len(value)] = memoryview(value)
+            self._offset += len(value)
+            return self
+        if self._try_write_contiguous(value, "H", 2, writeLength):
+            return self
+        if isinstance(value, Array) and value.typecode == "H":
+            n = len(value)
+            if writeLength:
+                self.sequenceLength(n)
+            self.align(2, n * 2)
+            self._resize_if_needed(n * 2)
+            struct.pack_into(
+                self._endian_fmt(f"{n}H"), self._buffer, self._offset, *value
+            )
+            self._offset += n * 2
+            return self
+        if writeLength:
+            self.sequenceLength(len(value))
+        for entry in value:
+            self.uint16(entry)
+        return self
+
+    def int32Array(
+        self,
+        value: Sequence[int] | bytes | bytearray | Array,
+        writeLength: bool | None = False,
+    ) -> CdrWriter:
+        if isinstance(value, (bytes, bytearray)):
+            if writeLength:
+                self.sequenceLength(len(value) // 4)
+            self.align(4, len(value))
+            self._resize_if_needed(len(value))
+            self._buffer[self._offset : self._offset + len(value)] = memoryview(value)
+            self._offset += len(value)
+            return self
+        if self._try_write_contiguous(value, "i", 4, writeLength):
+            return self
+        if isinstance(value, Array) and value.typecode == "i":
+            n = len(value)
+            if writeLength:
+                self.sequenceLength(n)
+            self.align(4, n * 4)
+            self._resize_if_needed(n * 4)
+            struct.pack_into(
+                self._endian_fmt(f"{n}i"), self._buffer, self._offset, *value
+            )
+            self._offset += n * 4
+            return self
+        if writeLength:
+            self.sequenceLength(len(value))
+        for entry in value:
+            self.int32(entry)
+        return self
+
+    def uint32Array(
+        self,
+        value: Sequence[int] | bytes | bytearray | Array,
+        writeLength: bool | None = False,
+    ) -> CdrWriter:
+        if isinstance(value, (bytes, bytearray)):
+            if writeLength:
+                self.sequenceLength(len(value) // 4)
+            self.align(4, len(value))
+            self._resize_if_needed(len(value))
+            self._buffer[self._offset : self._offset + len(value)] = memoryview(value)
+            self._offset += len(value)
+            return self
+        if self._try_write_contiguous(value, "I", 4, writeLength):
+            return self
+        if isinstance(value, Array) and value.typecode == "I":
+            n = len(value)
+            if writeLength:
+                self.sequenceLength(n)
+            self.align(4, n * 4)
+            self._resize_if_needed(n * 4)
+            struct.pack_into(
+                self._endian_fmt(f"{n}I"), self._buffer, self._offset, *value
+            )
+            self._offset += n * 4
+            return self
+        if writeLength:
+            self.sequenceLength(len(value))
+        for entry in value:
+            self.uint32(entry)
+        return self
+
+    def int64Array(
+        self,
+        value: Sequence[int] | bytes | bytearray | Array,
+        writeLength: bool | None = False,
+    ) -> CdrWriter:
+        if isinstance(value, (bytes, bytearray)):
+            if writeLength:
+                self.sequenceLength(len(value) // 8)
+            self.align(self._eight_byte_alignment, len(value))
+            self._resize_if_needed(len(value))
+            self._buffer[self._offset : self._offset + len(value)] = memoryview(value)
+            self._offset += len(value)
+            return self
+        if self._try_write_contiguous(
+            value, "q", self._eight_byte_alignment, writeLength
+        ):
+            return self
+        if isinstance(value, Array) and value.typecode == "q":
+            n = len(value)
+            if writeLength:
+                self.sequenceLength(n)
+            self.align(self._eight_byte_alignment, n * 8)
+            self._resize_if_needed(n * 8)
+            struct.pack_into(
+                self._endian_fmt(f"{n}q"), self._buffer, self._offset, *value
+            )
+            self._offset += n * 8
+            return self
+        if writeLength:
+            self.sequenceLength(len(value))
+        for entry in value:
+            self.int64(int(entry))
+        return self
+
+    def uint64Array(
+        self,
+        value: Sequence[int] | bytes | bytearray | Array,
+        writeLength: bool | None = False,
+    ) -> CdrWriter:
+        if isinstance(value, (bytes, bytearray)):
+            if writeLength:
+                self.sequenceLength(len(value) // 8)
+            self.align(self._eight_byte_alignment, len(value))
+            self._resize_if_needed(len(value))
+            self._buffer[self._offset : self._offset + len(value)] = memoryview(value)
+            self._offset += len(value)
+            return self
+        if self._try_write_contiguous(
+            value, "Q", self._eight_byte_alignment, writeLength
+        ):
+            return self
+        if isinstance(value, Array) and value.typecode == "Q":
+            n = len(value)
+            if writeLength:
+                self.sequenceLength(n)
+            self.align(self._eight_byte_alignment, n * 8)
+            self._resize_if_needed(n * 8)
+            struct.pack_into(
+                self._endian_fmt(f"{n}Q"), self._buffer, self._offset, *value
+            )
+            self._offset += n * 8
+            return self
+        if writeLength:
+            self.sequenceLength(len(value))
+        for entry in value:
+            self.uint64(int(entry))
+        return self
+
+    def float32Array(
+        self,
+        value: Sequence[float] | bytes | bytearray | Array,
+        writeLength: bool | None = False,
+    ) -> CdrWriter:
+        if isinstance(value, (bytes, bytearray)):
+            if writeLength:
+                self.sequenceLength(len(value) // 4)
+            self.align(4, len(value))
+            self._resize_if_needed(len(value))
+            self._buffer[self._offset : self._offset + len(value)] = memoryview(value)
+            self._offset += len(value)
+            return self
+        if self._try_write_contiguous(value, "f", 4, writeLength):
+            return self
+        if isinstance(value, Array) and value.typecode == "f":
+            n = len(value)
+            if writeLength:
+                self.sequenceLength(n)
+            self.align(4, n * 4)
+            self._resize_if_needed(n * 4)
+            struct.pack_into(
+                self._endian_fmt(f"{n}f"), self._buffer, self._offset, *value
+            )
+            self._offset += n * 4
+            return self
+        if writeLength:
+            self.sequenceLength(len(value))
+        for entry in value:
+            self.float32(float(entry))
+        return self
+
+    def float64Array(
+        self,
+        value: Sequence[float] | bytes | bytearray | Array,
+        writeLength: bool | None = False,
+    ) -> CdrWriter:
+        if isinstance(value, (bytes, bytearray)):
+            if writeLength:
+                self.sequenceLength(len(value) // 8)
+            self.align(self._eight_byte_alignment, len(value))
+            self._resize_if_needed(len(value))
+            self._buffer[self._offset : self._offset + len(value)] = memoryview(value)
+            self._offset += len(value)
+            return self
+        if self._try_write_contiguous(
+            value, "d", self._eight_byte_alignment, writeLength
+        ):
+            return self
+        if isinstance(value, Array) and value.typecode == "d":
+            n = len(value)
+            if writeLength:
+                self.sequenceLength(n)
+            self.align(self._eight_byte_alignment, n * 8)
+            self._resize_if_needed(n * 8)
+            struct.pack_into(
+                self._endian_fmt(f"{n}d"), self._buffer, self._offset, *value
+            )
+            self._offset += n * 8
+            return self
+        if writeLength:
+            self.sequenceLength(len(value))
+        for entry in value:
+            self.float64(float(entry))
+        return self
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _try_write_contiguous(
+        self,
+        value: object,
+        fmt_char: str,
+        align: int,
+        writeLength: bool | None,
+    ) -> bool:
+        """Attempt bulk copy from a contiguous typed buffer.
+
+        ``fmt_char`` is the expected PEP-3118 format character (without any
+        endianness prefix).  ``align`` is the alignment of the type in bytes.
+        Returns ``True`` if the value was written using a bulk copy,
+        ``False`` otherwise.
+        """
+
+        try:
+            mv = memoryview(cast(Buffer, value))
+        except TypeError:
+            return False
+
+        if not mv.c_contiguous or mv.itemsize != self._ITEMSIZE.get(fmt_char, 0):
+            return False
+
+        base = mv.format[-1]
+        prefix = mv.format[:-1]
+        if base != fmt_char:
+            return False
+
+        if prefix in ("", "@", "="):
+            mv_little = self._host_little_endian
+        elif prefix == "<":
+            mv_little = True
+        elif prefix in (">", "!"):
+            mv_little = False
+        else:
+            return False
+
+        if mv_little != self._little_endian:
+            return False
+
+        n = mv.nbytes // mv.itemsize
+        if writeLength:
+            self.sequenceLength(n)
+        self.align(align, mv.nbytes)
+        self._resize_if_needed(mv.nbytes)
+        self._buffer[self._offset : self._offset + mv.nbytes] = mv.cast("B")
+        self._offset += mv.nbytes
+        return True
+
+    def reset_origin(self) -> None:
+        """Set the origin used for alignment to the current offset."""
+
+        self._origin = self._offset
+
+    def align(self, size: int, bytesToWrite: int | None = None) -> None:
+        if bytesToWrite is None:
+            bytesToWrite = size
+        if size <= 0:
+            self._resize_if_needed(bytesToWrite)
+            return
+        alignment = (self._offset - self._origin) % size
+        padding = size - alignment if alignment > 0 else 0
+        self._resize_if_needed(padding + bytesToWrite)
+        for _ in range(padding):
+            self._buffer[self._offset] = 0
+            self._offset += 1
+
+    def _endian_fmt(self, fmt: str) -> str:
+        return ("<" if self._little_endian else ">") + fmt
+
+    def _resize_if_needed(self, additional: int) -> None:
+        capacity = self._offset + additional
+        if len(self._buffer) < capacity:
+            doubled = len(self._buffer) * 2
+            new_capacity = doubled if doubled > capacity else capacity
+            self._resize(new_capacity)
+
+    def _resize(self, capacity: int) -> None:
+        if len(self._buffer) >= capacity:
+            return
+        self._buffer.extend(b"\x00" * (capacity - len(self._buffer)))
+
+    def _member_header_v1(
+        self, mustUnderstand: bool, id: int, objectSize: int
+    ) -> CdrWriter:
+        self.align(4)
+        must_flag = (1 << 14) if mustUnderstand else 0
+        use_extended = id > 0x3F00 or objectSize > 0xFFFF
+        if not use_extended:
+            self.uint16(must_flag | id)
+            self.uint16(objectSize & 0xFFFF)
+        else:
+            self.uint16(must_flag | EXTENDED_PID)
+            self.uint16(8)
+            self.uint32(id)
+            self.uint32(objectSize)
+        self.reset_origin()
+        return self
+
+    def _member_header_v2(
+        self,
+        mustUnderstand: bool,
+        id: int,
+        objectSize: int,
+        lengthCode: LengthCode | None,
+    ) -> CdrWriter:
+        if id > 0x0FFFFFFF:
+            raise ValueError(
+                "Member ID %d is too large. Max value is %d" % (id, 0x0FFFFFFF)
+            )
+
+        must_flag = (1 << 31) if mustUnderstand else 0
+        final_length_code: LengthCode = (
+            lengthCode
+            if lengthCode is not None
+            else get_length_code_for_object_size(objectSize)
+        )
+        header = must_flag | (final_length_code << 28) | id
+        self.uint32(header)
+
+        if final_length_code in (0, 1, 2, 3):
+            should_be = length_code_to_object_sizes[final_length_code]
+            if objectSize != should_be:
+                raise ValueError(
+                    (
+                        "Cannot write a length code %d header with an object size not "
+                        "equal to %d"
+                    )
+                    % (final_length_code, should_be)
+                )
+        elif final_length_code in (4, 5):
+            self.uint32(objectSize)
+        elif final_length_code == 6:
+            if objectSize % 4 != 0:
+                raise ValueError(
+                    (
+                        "Cannot write a length code 6 header with an object size "
+                        "that is not a multiple of 4"
+                    )
+                )
+            self.uint32(objectSize >> 2)
+        elif final_length_code == 7:
+            if objectSize % 8 != 0:
+                raise ValueError(
+                    (
+                        "Cannot write a length code 7 header with an object size "
+                        "that is not a multiple of 8"
+                    )
+                )
+            self.uint32(objectSize >> 3)
+        else:
+            raise ValueError("Unexpected length code %d" % final_length_code)
+
+        return self

--- a/mcap_ros2idl_support/decode_factory.py
+++ b/mcap_ros2idl_support/decode_factory.py
@@ -6,9 +6,13 @@ from typing import Callable, Optional
 
 from mcap.decoder import DecoderFactory
 from mcap.records import Schema
-from ros2idl_parser import parse_ros2idl
-from rosmsg import parse as parse_ros2msg
-from rosmsg2_serialization import MessageReader, MessageReaderOptions
+
+from mcap_ros2idl_support.ros2idl_parser import parse_ros2idl
+from mcap_ros2idl_support.rosmsg import parse as parse_ros2msg
+from mcap_ros2idl_support.rosmsg2_serialization import (
+    MessageReader,
+    MessageReaderOptions,
+)
 
 
 class Ros2DecodeFactory(DecoderFactory):

--- a/mcap_ros2idl_support/message_definition/__init__.py
+++ b/mcap_ros2idl_support/message_definition/__init__.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from enum import Enum
+from typing import List, Optional, Sequence, Union
+
+# Type aliases matching the TypeScript package
+ConstantValue = Union[str, int, float, bool, None]
+DefaultValue = Union[
+    str,
+    int,
+    float,
+    bool,
+    Sequence[str],
+    Sequence[int],
+    Sequence[float],
+    Sequence[bool],
+    None,
+]
+
+
+@dataclass
+class MessageDefinitionField:
+    """A single field in a message definition."""
+
+    type: str
+    name: str
+    isComplex: bool = False
+    enumType: Optional[str] = None
+    isArray: bool = False
+    arrayLength: Optional[int] = None
+    isConstant: bool = False
+    value: ConstantValue = None
+    valueText: Optional[str] = None
+    upperBound: Optional[int] = None
+    arrayUpperBound: Optional[int] = None
+    defaultValue: DefaultValue = None
+
+
+@dataclass
+class UnionCase:
+    """A single case within a union definition."""
+
+    predicates: List[Union[int, bool]]
+    type: MessageDefinitionField
+
+
+class AggregatedKind(Enum):
+    MODULE = "module"
+    STRUCT = "struct"
+    UNION = "union"
+
+
+@dataclass
+class MessageDefinition:
+    """A message definition containing an optional name and a list of fields."""
+
+    name: Optional[str] = None
+    aggregatedKind: AggregatedKind = AggregatedKind.STRUCT
+    switchType: Optional[str] = None
+    definitions: List[MessageDefinitionField] = dataclass_field(default_factory=list)
+    cases: List[UnionCase] = dataclass_field(default_factory=list)
+    defaultCase: Optional[MessageDefinitionField] = None
+
+
+def is_msg_def_equal(a: MessageDefinition, b: MessageDefinition) -> bool:
+    """Return whether two MessageDefinition instances are equal."""
+
+    return a == b
+
+
+__all__ = [
+    "ConstantValue",
+    "DefaultValue",
+    "AggregatedKind",
+    "MessageDefinition",
+    "MessageDefinitionField",
+    "UnionCase",
+    "is_msg_def_equal",
+]

--- a/mcap_ros2idl_support/omgidl_parser/__init__.py
+++ b/mcap_ros2idl_support/omgidl_parser/__init__.py
@@ -1,0 +1,41 @@
+from mcap_ros2idl_support.message_definition import MessageDefinitionField
+from mcap_ros2idl_support.omgidl_parser.parse import (
+    Constant,
+    Enum,
+    Field,
+    Module,
+    Struct,
+    Typedef,
+    Union,
+    UnionCase,
+    parse_idl,
+)
+from mcap_ros2idl_support.omgidl_parser.process import (
+    IDLMessageDefinition,
+    IDLModuleDefinition,
+    IDLStructDefinition,
+    IDLUnionDefinition,
+    build_map,
+    parse_idl_message_definitions,
+    to_idl_message_definitions,
+)
+
+__all__ = [
+    "parse_idl",
+    "Field",
+    "Struct",
+    "Module",
+    "Constant",
+    "Enum",
+    "Typedef",
+    "Union",
+    "UnionCase",
+    "MessageDefinitionField",
+    "IDLStructDefinition",
+    "IDLModuleDefinition",
+    "IDLUnionDefinition",
+    "IDLMessageDefinition",
+    "build_map",
+    "to_idl_message_definitions",
+    "parse_idl_message_definitions",
+]

--- a/mcap_ros2idl_support/omgidl_parser/parse.py
+++ b/mcap_ros2idl_support/omgidl_parser/parse.py
@@ -1,0 +1,578 @@
+from __future__ import annotations
+
+import codecs
+import threading
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+from typing import Union as TypingUnion
+
+from lark import Lark, Transformer
+
+# A slightly larger subset grammar supporting modules, structs, constants, enums,
+# typedefs and unions
+IDL_GRAMMAR = r"""
+start: definition+
+
+definition: annotations? (module
+          | struct
+          | constant
+          | enum
+          | typedef
+          | union)
+          | import_stmt
+          | include_stmt
+
+module: "module" NAME "{" definition* "}" semicolon?
+
+struct: "struct" NAME "{" field* "}" semicolon?
+
+enum: "enum" NAME "{" enumerator ("," enumerator)* "}" semicolon?
+
+enumerator: annotations? NAME enum_value?
+enum_value: "@value" "(" INT ")"
+
+constant: "const" type NAME "=" const_value semicolon
+# Allow multiple adjacent string literals, which are concatenated (e.g., "part1" "part2")
+const_value: STRING+ -> const_string
+           | BOOL -> const_bool
+           | const_sum
+
+const_sum: const_atom ("+" const_atom)*
+
+?const_atom: SIGNED_INT -> const_int
+          | SIGNED_FLOAT -> const_float
+          | scoped_name
+
+typedef: "typedef" type NAME array? semicolon
+
+union: "union" NAME "switch" "(" type ")" "{" union_case+ "}" semicolon?
+union_case: "case" case_predicates ":" field
+          | "default" ":" field
+case_predicates: const_value ("," const_value)*
+
+field: annotations? type NAME array? semicolon
+
+import_stmt: "import" STRING semicolon
+
+include_stmt: "#include" (STRING | "<" /[^>]+/ ">")
+
+type: sequence_type
+    | string_type
+    | BUILTIN_TYPE
+    | scoped_name
+
+sequence_type: "sequence" "<" type ("," const_sum)? ">"
+
+string_type: STRING_KW string_bound?
+           | WSTRING_KW string_bound?
+
+string_bound: "<" const_sum ">"
+
+scoped_name: NAME ("::" NAME)*
+
+BUILTIN_TYPE: /(unsigned\s+(short|long(\s+long)?)|long\s+double|double|float|short|long\s+long|long|int8|uint8|int16|uint16|int32|uint32|int64|uint64|byte|octet|wchar|char|boolean)\b/  # noqa: E501
+STRING_KW: "string"
+WSTRING_KW: "wstring"
+NAME: /[A-Za-z_][A-Za-z0-9_]*/
+
+array: ("[" const_sum "]")+
+
+semicolon: ";"
+
+%import common.INT
+BOOL.2: /(?i:\btrue\b|\bfalse\b)/
+%import common.SIGNED_INT
+%import common.SIGNED_FLOAT
+# STRING matches both double-quoted and single-quoted string literals, including
+# escaped characters. We avoid inline regex flags (e.g., ``(?s)``) so the grammar
+# works with Python's built-in ``re`` module without requiring the third-party
+# ``regex`` package. Instead, ``[\s\S]`` is used to match any character,
+# including newlines, within escape sequences.
+STRING: /"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'/
+%import common.WS
+
+COMMENT: /\/\/[^\n]*|\/\*[\s\S]*?\*\//
+%ignore WS
+%ignore COMMENT
+
+# Annotations support two parameter formats:
+#   - Named parameters: @foo(bar=1, baz=2)
+#   - Single value:     @foo(42)
+# Both forms are supported via the annotation_params rule below.
+annotation: "@" NAME ("(" annotation_params ")")?
+annotation_params: named_annotation_params
+                   | const_value
+named_annotation_params: named_annotation_param ("," named_annotation_param)*
+named_annotation_param: NAME "=" const_value
+annotations: annotation+
+"""
+
+
+# Build a Lark parser per thread. Constructing the parser is relatively
+# expensive, and doing it on every call to ``parse_idl`` results in significant
+# overhead. Reusing a parser instance per thread drastically reduces the
+# per-call parsing cost while remaining thread-safe.
+_THREAD_LOCAL = threading.local()
+
+
+def _get_parser() -> Lark:
+    parser = getattr(_THREAD_LOCAL, "parser", None)
+    if parser is None:
+        parser = Lark(
+            IDL_GRAMMAR, start="start", parser="lalr", maybe_placeholders=False
+        )
+        _THREAD_LOCAL.parser = parser
+    return parser
+
+
+@dataclass
+class Field:
+    name: str
+    type: str
+    array_lengths: List[int] = field(default_factory=list)
+    is_sequence: bool = False
+    sequence_bound: Optional[int] = None
+    string_upper_bound: Optional[int] = None
+    annotations: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Constant:
+    name: str
+    type: str
+    value: TypingUnion[int, float, bool, str]
+    annotations: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Enum:
+    name: str
+    enumerators: List[Constant] = field(default_factory=list)
+    annotations: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Struct:
+    name: str
+    fields: List[Field] = field(default_factory=list)
+    annotations: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Typedef:
+    name: str
+    type: str
+    array_lengths: List[int] = field(default_factory=list)
+    is_sequence: bool = False
+    sequence_bound: Optional[int] = None
+    annotations: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class UnionCase:
+    predicates: List[int | bool | str]
+    field: Field
+
+
+@dataclass
+class Union:
+    name: str
+    switch_type: str
+    cases: List[UnionCase] = field(default_factory=list)
+    default: Optional[Field] = None
+    annotations: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Module:
+    name: str
+    definitions: List[Struct | Module | Constant | Enum | Typedef | Union] = field(
+        default_factory=list
+    )
+    annotations: dict[str, Any] = field(default_factory=dict)
+
+
+class _Transformer(Transformer):
+    _NORMALIZATION = {
+        "long double": "float64",
+        "double": "float64",
+        "float": "float32",
+        "short": "int16",
+        "unsigned short": "uint16",
+        "unsigned long long": "uint64",
+        "unsigned long": "uint32",
+        "long long": "int64",
+        "long": "int32",
+        "boolean": "bool",
+    }
+
+    _BUILTIN_TYPES = {
+        "float64",
+        "float32",
+        "int16",
+        "uint16",
+        "uint64",
+        "uint32",
+        "int64",
+        "int32",
+        "int8",
+        "uint8",
+        "byte",
+        "octet",
+        "wchar",
+        "char",
+        "string",
+        "wstring",
+        "bool",
+    }
+
+    def __init__(self):
+        super().__init__()
+        # Map identifiers (constants and enum values) to their evaluated numeric values
+        self._constants: dict[str, int | float | bool | str] = {}
+
+    def start(self, items):
+        return [item for item in items if item is not None]
+
+    def definition(self, items):
+        if len(items) == 1:
+            return items[0]
+        annotations, decl = items
+        if decl is None:
+            return None
+        if isinstance(annotations, dict) and hasattr(decl, "annotations"):
+            decl.annotations = annotations
+        return decl
+
+    def NAME(self, token):
+        return str(token)
+
+    def scoped_name(self, items):
+        return "::".join(items)
+
+    def type(self, items):
+        (t,) = items
+        if isinstance(t, tuple):
+            if t[0] == "sequence":
+                inner, bound = t[1], t[2]
+                return ("sequence", self._NORMALIZATION.get(inner, inner), bound)
+            base, bound = t
+            return (self._NORMALIZATION.get(base, base), bound)
+        if isinstance(t, str):
+            return self._NORMALIZATION.get(t, t)
+        token = str(t)
+        return self._NORMALIZATION.get(token, token)
+
+    def sequence_type(self, items):
+        inner = items[0]
+        bound = items[1] if len(items) > 1 else None
+        if bound is not None:
+            try:
+                bound = int(bound)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid sequence bound value '{bound}'"
+                    " in IDL. Expected an integer."
+                )
+        return ("sequence", inner, bound)
+
+    def string_type(self, items):
+        base = str(items[0])
+        bound = items[1] if len(items) > 1 else None
+        if bound is not None:
+            return (base, bound)
+        return base
+
+    def string_bound(self, items):
+        (value,) = items
+        try:
+            return int(value)
+        except ValueError:
+            raise ValueError(f"Invalid string bound value: {value!r}")
+
+    def INT(self, token):
+        return int(token)
+
+    def const_int(self, items):
+        (token,) = items
+        return int(token)
+
+    def STRING(self, token):
+        value = str(token)[1:-1]
+        return codecs.decode(value, "unicode_escape")
+
+    def array(self, items):
+        return [int(itm) for itm in items]
+
+    def semicolon(self, _):
+        return None
+
+    def import_stmt(self, _items):
+        return None
+
+    def include_stmt(self, _items):
+        return None
+
+    def annotation(self, items):
+        name = items[0]
+        value = items[1] if len(items) > 1 else True
+        return (name, value)
+
+    def annotation_params(self, items):
+        (value,) = items
+        return value
+
+    def named_annotation_params(self, items):
+        return dict(items)
+
+    def named_annotation_param(self, items):
+        name, value = items
+        return (name, value)
+
+    def annotations(self, items):
+        return dict(items)
+
+    def field(self, items):
+        idx = 0
+        annotations = {}
+        if items and isinstance(items[0], dict):
+            annotations = items[0]
+            idx = 1
+        type_, name, *rest = items[idx:]
+        array_lengths: List[int] = []
+        for itm in rest:
+            if isinstance(itm, list):
+                array_lengths = itm
+        is_sequence = False
+        sequence_bound = None
+        string_upper_bound = None
+        if isinstance(type_, tuple):
+            if type_[0] == "sequence":
+                is_sequence = True
+                sequence_bound = type_[2]
+                type_ = type_[1]
+                if isinstance(type_, tuple):
+                    string_upper_bound = type_[1]
+                    type_ = type_[0]
+            else:
+                string_upper_bound = type_[1]
+                type_ = type_[0]
+        return Field(
+            name=name,
+            type=type_,
+            array_lengths=array_lengths,
+            is_sequence=is_sequence,
+            sequence_bound=sequence_bound,
+            string_upper_bound=string_upper_bound,
+            annotations=annotations,
+        )
+
+    def const_string(self, items):
+        return "".join(items)
+
+    def const_bool(self, items):
+        (token,) = items
+        return str(token).lower() == "true"
+
+    def const_float(self, items):
+        (token,) = items
+        return float(token)
+
+    def const_sum(self, items):
+        total = None
+        for idx, item in enumerate(items):
+            if isinstance(item, str):
+                if item not in self._constants:
+                    raise ValueError(f"Unknown identifier '{item}'")
+                val = self._constants[item]
+            else:
+                val = item
+            if idx == 0:
+                total = val
+            else:
+                if not isinstance(total, (int, float)) or not isinstance(
+                    val, (int, float)
+                ):
+                    raise ValueError("Addition only allowed on numeric constants")
+                total += val
+        return total
+
+    def const_value(self, items):
+        (value,) = items
+        return value
+
+    def constant(self, items):
+        # items: TYPE, NAME, value, None
+        type_, name, value, _ = items
+        const = Constant(name=name, type=type_, value=value)
+        self._constants[name] = value
+        return const
+
+    def typedef(self, items):
+        type_, name, *rest = items
+        array_lengths: List[int] = []
+        for itm in rest:
+            if isinstance(itm, list):
+                array_lengths = itm
+        is_sequence = False
+        sequence_bound = None
+        if isinstance(type_, tuple) and type_[0] == "sequence":
+            is_sequence = True
+            sequence_bound = type_[2]
+            type_ = type_[1]
+        return Typedef(
+            name=name,
+            type=type_,
+            array_lengths=array_lengths,
+            is_sequence=is_sequence,
+            sequence_bound=sequence_bound,
+        )
+
+    def case_predicates(self, items):
+        return items
+
+    def union_case(self, items):
+        if len(items) == 1:
+            (field,) = items
+            predicates: List[int | str] = []
+        else:
+            predicates, field = items
+        return UnionCase(predicates=predicates, field=field)
+
+    def union(self, items):
+        name = items[0]
+        switch_type = items[1]
+        cases: List[UnionCase] = []
+        default: Optional[Field] = None
+        for itm in items[2:]:
+            if isinstance(itm, UnionCase):
+                if itm.predicates:
+                    cases.append(itm)
+                else:
+                    default = itm.field
+        return Union(name=name, switch_type=switch_type, cases=cases, default=default)
+
+    def enum_value(self, items):
+        (_, _, val, _) = items
+        return val
+
+    def enumerator(self, items):
+        idx = 0
+        if items and isinstance(items[0], dict):
+            idx = 1
+        name = items[idx]
+        value = items[idx + 1] if len(items) > idx + 1 else None
+        return (name, value)
+
+    def enum(self, items):
+        name = items[0]
+        enumerators_raw = [it for it in items[1:] if isinstance(it, tuple)]
+        constants: List[Constant] = []
+        current = -1
+        for enum_name, enum_val in enumerators_raw:
+            if enum_val is not None:
+                current = enum_val
+            else:
+                current += 1
+            constants.append(Constant(name=enum_name, type="uint32", value=current))
+            # Register enumerator both as unscoped and scoped (EnumName::Enumerator)
+            self._constants[enum_name] = current
+            self._constants[f"{name}::{enum_name}"] = current
+        return Enum(name=name, enumerators=constants)
+
+    def struct(self, items):
+        name = items[0]
+        fields = [i for i in items[1:] if isinstance(i, Field)]
+        return Struct(name=name, fields=fields)
+
+    def module(self, items):
+        name = items[0]
+        definitions = [item for item in items[1:] if item is not None]
+        return Module(name=name, definitions=definitions)
+
+    def resolve_types(
+        self, definitions: List[Struct | Module | Constant | Enum | Typedef | Union]
+    ):
+        named_types: set[str] = set()
+
+        def collect(
+            defs: List[Struct | Module | Constant | Enum | Typedef | Union],
+            scope: List[str],
+        ):
+            for d in defs:
+                if isinstance(d, (Struct, Union, Typedef, Enum)):
+                    full = "::".join([*scope, d.name])
+                    named_types.add(full)
+                if isinstance(d, Module):
+                    collect(d.definitions, [*scope, d.name])
+
+        collect(definitions, [])
+
+        def resolve_field(f: Field, scope: List[str]):
+            if f.type in self._BUILTIN_TYPES:
+                return
+            if f.type.startswith("::"):
+                f.type = f.type[2:]
+                return
+            if f.type in named_types:
+                return
+            resolved = None
+            for i in range(len(scope), -1, -1):
+                candidate = "::".join([*scope[:i], f.type])
+                if candidate in named_types:
+                    resolved = candidate
+                    break
+            if resolved:
+                f.type = resolved
+
+        def resolve(
+            defs: List[Struct | Module | Constant | Enum | Typedef | Union],
+            scope: List[str],
+        ):
+            for d in defs:
+                if isinstance(d, Struct):
+                    for f in d.fields:
+                        resolve_field(f, scope)
+                elif isinstance(d, Union):
+                    d.switch_type = self._NORMALIZATION.get(
+                        d.switch_type, d.switch_type
+                    )
+                    if (
+                        d.switch_type not in self._BUILTIN_TYPES
+                        and not d.switch_type.startswith("::")
+                        and "::" not in d.switch_type
+                    ):
+                        for i in range(len(scope), -1, -1):
+                            candidate = "::".join([*scope[:i], d.switch_type])
+                            if candidate in named_types:
+                                d.switch_type = candidate
+                                break
+                    for case in d.cases:
+                        resolve_field(case.field, scope)
+                    if d.default:
+                        resolve_field(d.default, scope)
+                elif isinstance(d, Typedef):
+                    if (
+                        d.type not in self._BUILTIN_TYPES
+                        and not d.type.startswith("::")
+                        and "::" not in d.type
+                    ):
+                        for i in range(len(scope), -1, -1):
+                            candidate = "::".join([*scope[:i], d.type])
+                            if candidate in named_types:
+                                d.type = candidate
+                                break
+                elif isinstance(d, Module):
+                    resolve(d.definitions, [*scope, d.name])
+
+        resolve(definitions, [])
+
+
+def parse_idl(source: str) -> List[Struct | Module | Constant | Enum | Typedef | Union]:
+    """Parse an IDL definition string into structured objects."""
+    parser = _get_parser()
+    tree = parser.parse(source)
+    transformer = _Transformer()
+    result = transformer.transform(tree)
+    transformer.resolve_types(result)
+    return result

--- a/mcap_ros2idl_support/omgidl_parser/process.py
+++ b/mcap_ros2idl_support/omgidl_parser/process.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Union, cast
+
+from mcap_ros2idl_support.message_definition import (
+    AggregatedKind,
+    MessageDefinitionField,
+    UnionCase,
+)
+from mcap_ros2idl_support.omgidl_parser.parse import (
+    Constant,
+    Enum,
+    Field,
+    Module,
+    Struct,
+    Typedef,
+)
+from mcap_ros2idl_support.omgidl_parser.parse import Union as IDLUnion
+
+# ---------------------------------------------------------------------------
+# Message definition dataclasses -------------------------------------------------
+
+
+@dataclass
+class IDLStructDefinition:
+    name: str
+    definitions: List[MessageDefinitionField]
+    aggregatedKind: AggregatedKind = AggregatedKind.STRUCT
+    annotations: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class IDLModuleDefinition:
+    name: str
+    definitions: List[MessageDefinitionField]
+    aggregatedKind: AggregatedKind = AggregatedKind.MODULE
+    annotations: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class IDLUnionDefinition:
+    name: str
+    switchType: str
+    cases: List[UnionCase]
+    defaultCase: Optional[MessageDefinitionField] = None
+    aggregatedKind: AggregatedKind = AggregatedKind.UNION
+    annotations: Optional[Dict[str, Any]] = None
+
+
+IDLMessageDefinition = Union[
+    IDLStructDefinition, IDLModuleDefinition, IDLUnionDefinition
+]
+
+# ---------------------------------------------------------------------------
+# Map building -------------------------------------------------------------------
+
+
+Definition = Union[Struct, Module, Constant, Enum, Typedef, IDLUnion]
+
+
+def build_map(definitions: Iterable[Definition]) -> dict[str, Definition]:
+    """Traverse parsed nodes and return a map of fully scoped names to nodes."""
+
+    idl_map: dict[str, Definition] = {}
+
+    def traverse(defn: Definition, scope: List[str]) -> None:
+        if isinstance(defn, Module):
+            for sub in defn.definitions:
+                traverse(sub, [*scope, defn.name])
+            scoped = "::".join([*scope, defn.name])
+            idl_map[scoped] = defn
+        elif isinstance(defn, Enum):
+            scoped = "::".join([*scope, defn.name])
+            idl_map[scoped] = defn
+            for enumerator in defn.enumerators:
+                scoped_enum = "::".join([*scope, defn.name, enumerator.name])
+                idl_map[scoped_enum] = enumerator
+        else:
+            scoped = "::".join([*scope, defn.name])
+            idl_map[scoped] = defn
+
+    for definition in definitions:
+        traverse(definition, [])
+
+    return idl_map
+
+
+# ---------------------------------------------------------------------------
+# Conversion helpers -------------------------------------------------------------
+
+
+def _resolve_typedef(
+    type_name: str,
+    typedefs: Dict[str, Typedef],
+) -> tuple[str, List[int], bool, Optional[int], Optional[int]]:
+    """Resolve typedef chain returning final type and collected modifiers.
+
+    Returns a tuple of (type, array_lengths, is_sequence, sequence_bound,
+    string_upper_bound).
+    """
+
+    t = type_name
+    array_lengths: List[int] = []
+    is_sequence = False
+    seq_bound: Optional[int] = None
+    str_bound: Optional[int] = None
+    visited: set[str] = set()
+    while t in typedefs and t not in visited:
+        visited.add(t)
+        td = typedefs[t]
+        base_type = td.type
+
+        # Detect composing variable length arrays within typedef chains.
+        if isinstance(base_type, str) and base_type in typedefs:
+            inner_td = typedefs[base_type]
+            outer_has_array = bool(td.array_lengths) or td.is_sequence
+            inner_has_array = bool(inner_td.array_lengths) or inner_td.is_sequence
+            if outer_has_array and inner_has_array:
+                outer_fixed = bool(td.array_lengths) and not td.is_sequence
+                inner_fixed = bool(inner_td.array_lengths) and not inner_td.is_sequence
+                if not (outer_fixed and inner_fixed):
+                    raise ValueError(
+                        (
+                            "We do not support composing variable length arrays "
+                            "with typedefs"
+                        )
+                    )
+
+        if isinstance(base_type, tuple):
+            if base_type[0] == "sequence":
+                is_sequence = True
+                seq_bound = base_type[2]
+                base_type = base_type[1]
+            else:
+                str_bound = base_type[1]
+                base_type = base_type[0]
+        t = base_type
+        if td.array_lengths:
+            array_lengths.extend(td.array_lengths)
+        if td.is_sequence:
+            is_sequence = True
+            if td.sequence_bound is not None:
+                seq_bound = td.sequence_bound
+        # string bounds are not currently represented on Typedef in parse.py
+    return t, array_lengths, is_sequence, seq_bound, str_bound
+
+
+def _convert_constant(
+    const: Constant,
+    typedefs: Dict[str, Typedef],
+    idl_map: Dict[str, Definition],
+) -> MessageDefinitionField:
+    t, _arr, _is_seq, _seq_bound, _str_bound = _resolve_typedef(const.type, typedefs)
+    enum_type = None
+    is_complex = False
+    ref = idl_map.get(t)
+    if isinstance(ref, Enum):
+        enum_type = t
+        t = "uint32"
+    elif isinstance(ref, (Struct, IDLUnion)):
+        is_complex = True
+    return MessageDefinitionField(
+        name=const.name,
+        type=t,
+        isComplex=is_complex,
+        enumType=enum_type,
+        isConstant=True,
+        value=const.value,
+        valueText=str(const.value),
+    )
+
+
+def _convert_field(
+    field: Field,
+    typedefs: Dict[str, Typedef],
+    idl_map: Dict[str, Definition],
+) -> MessageDefinitionField:
+    t, td_arrays, td_is_seq, td_seq_bound, td_str_bound = _resolve_typedef(
+        field.type, typedefs
+    )
+
+    field_has_array = bool(field.array_lengths) or field.is_sequence
+    td_has_array = bool(td_arrays) or td_is_seq
+    field_fixed = bool(field.array_lengths) and not field.is_sequence
+    td_fixed = bool(td_arrays) and not td_is_seq
+    if field_has_array and td_has_array and (not field_fixed or not td_fixed):
+        raise ValueError(
+            "We do not support composing variable length arrays with typedefs"
+        )
+
+    array_lengths = list(field.array_lengths)
+    if td_arrays:
+        array_lengths.extend(td_arrays)
+    if len(array_lengths) > 1:
+        raise ValueError(
+            "Multi-dimensional arrays are not supported in MessageDefinition type"
+        )
+    is_sequence = field.is_sequence or td_is_seq
+    sequence_bound = field.sequence_bound if field.is_sequence else td_seq_bound
+    upper_bound = (
+        field.string_upper_bound
+        if field.string_upper_bound is not None
+        else td_str_bound
+    )
+
+    enum_type = None
+    is_complex = False
+    ref = idl_map.get(t)
+    if isinstance(ref, Enum):
+        enum_type = t
+        t = "uint32"
+    elif isinstance(ref, (Struct, IDLUnion)):
+        is_complex = True
+
+    annotations = field.annotations or None
+    default_value = None
+    if annotations and "default" in annotations:
+        default_value = annotations["default"]
+
+    is_array = bool(array_lengths) or is_sequence
+
+    return MessageDefinitionField(
+        type=t,
+        name=field.name,
+        isComplex=is_complex,
+        isArray=is_array,
+        arrayLength=array_lengths[0] if array_lengths else None,
+        arrayUpperBound=sequence_bound if is_sequence else None,
+        enumType=enum_type,
+        upperBound=upper_bound,
+        defaultValue=default_value,
+    )
+
+
+def _convert_union(
+    name: str,
+    union: IDLUnion,
+    typedefs: Dict[str, Typedef],
+    idl_map: Dict[str, Definition],
+) -> IDLUnionDefinition:
+    switch_type, _arr, _is_seq, _seq_bound, _str_bound = _resolve_typedef(
+        union.switch_type, typedefs
+    )
+    ref = idl_map.get(switch_type)
+    if isinstance(ref, Enum):
+        switch_type = "uint32"
+
+    cases: List[UnionCase] = []
+    for case in union.cases:
+        field_def = _convert_field(case.field, typedefs, idl_map)
+        # ``case.predicates`` may be typed broadly by the parser, but by this
+        # stage they should have been resolved to integers or booleans.
+        predicates = cast(List[int | bool], case.predicates)
+        cases.append(UnionCase(predicates=predicates, type=field_def))
+
+    default_field = None
+    if union.default is not None:
+        default_field = _convert_field(union.default, typedefs, idl_map)
+
+    return IDLUnionDefinition(
+        name=name,
+        switchType=switch_type,
+        cases=cases,
+        defaultCase=default_field,
+        annotations=union.annotations or None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API ---------------------------------------------------------------------
+
+
+def to_idl_message_definitions(
+    idl_map: dict[str, Definition],
+) -> List[IDLMessageDefinition]:
+    """Convert map entries into flattened message definitions."""
+
+    typedefs: Dict[str, Typedef] = {
+        name: node for name, node in idl_map.items() if isinstance(node, Typedef)
+    }
+
+    message_definitions: List[IDLMessageDefinition] = []
+    top_level_consts: List[MessageDefinitionField] = []
+
+    for scoped_name, node in idl_map.items():
+        if isinstance(node, Struct):
+            fields = [_convert_field(f, typedefs, idl_map) for f in node.fields]
+            message_definitions.append(
+                IDLStructDefinition(
+                    name=scoped_name,
+                    definitions=fields,
+                    annotations=node.annotations or None,
+                )
+            )
+        elif isinstance(node, Module):
+            const_fields = [
+                _convert_constant(d, typedefs, idl_map)
+                for d in node.definitions
+                if isinstance(d, Constant)
+            ]
+            if const_fields:
+                message_definitions.append(
+                    IDLModuleDefinition(name=scoped_name, definitions=const_fields)
+                )
+        elif isinstance(node, Constant):
+            if "::" not in scoped_name:
+                top_level_consts.append(_convert_constant(node, typedefs, idl_map))
+        elif isinstance(node, Enum):
+            const_fields = [
+                _convert_constant(e, typedefs, idl_map) for e in node.enumerators
+            ]
+            message_definitions.append(
+                IDLModuleDefinition(name=scoped_name, definitions=const_fields)
+            )
+        elif isinstance(node, IDLUnion):
+            message_definitions.append(
+                _convert_union(scoped_name, node, typedefs, idl_map)
+            )
+        # Typedefs are only used for resolution; they do not produce output.
+
+    if top_level_consts:
+        message_definitions.append(
+            IDLModuleDefinition(name="", definitions=top_level_consts)
+        )
+
+    return message_definitions
+
+
+def parse_idl_message_definitions(source: str) -> List[IDLMessageDefinition]:
+    """Parse IDL text and return flattened message definitions."""
+
+    from mcap_ros2idl_support.omgidl_parser.parse import parse_idl
+
+    parsed = parse_idl(source)
+    idl_map = build_map(parsed)
+    return to_idl_message_definitions(idl_map)
+
+
+__all__ = [
+    "IDLStructDefinition",
+    "IDLModuleDefinition",
+    "IDLUnionDefinition",
+    "IDLMessageDefinition",
+    "build_map",
+    "to_idl_message_definitions",
+    "parse_idl_message_definitions",
+]

--- a/mcap_ros2idl_support/ros2idl_parser/__init__.py
+++ b/mcap_ros2idl_support/ros2idl_parser/__init__.py
@@ -1,0 +1,15 @@
+from mcap_ros2idl_support.message_definition import (
+    AggregatedKind,
+    MessageDefinition,
+    MessageDefinitionField,
+    UnionCase,
+)
+from mcap_ros2idl_support.ros2idl_parser.parse import parse_ros2idl
+
+__all__ = [
+    "parse_ros2idl",
+    "AggregatedKind",
+    "MessageDefinition",
+    "MessageDefinitionField",
+    "UnionCase",
+]

--- a/mcap_ros2idl_support/ros2idl_parser/parse.py
+++ b/mcap_ros2idl_support/ros2idl_parser/parse.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from typing import List
+
+from mcap_ros2idl_support.message_definition import (
+    AggregatedKind,
+    MessageDefinition,
+    MessageDefinitionField,
+    UnionCase,
+)
+from mcap_ros2idl_support.omgidl_parser.process import (
+    IDLModuleDefinition,
+    IDLStructDefinition,
+    IDLUnionDefinition,
+    parse_idl_message_definitions,
+)
+
+ROS2IDL_HEADER = re.compile(r"={80}\nIDL: [a-zA-Z][\w]*(?:\/[a-zA-Z][\w]*)*")
+
+
+def parse_ros2idl(message_definition: str) -> List[MessageDefinition]:
+    """Parse ros2idl schema into message definitions."""
+
+    idl_conformed = ROS2IDL_HEADER.sub("", message_definition)
+    idl_defs = parse_idl_message_definitions(idl_conformed)
+
+    message_defs: List[MessageDefinition] = []
+    for defn in idl_defs:
+        if isinstance(defn, IDLStructDefinition):
+            fields: List[MessageDefinitionField] = []
+            for field in defn.definitions:
+                f = replace(field)
+                f.type = _normalize_name(f.type)
+                if f.enumType:
+                    f.enumType = _normalize_name(f.enumType)
+                fields.append(f)
+            message_defs.append(
+                MessageDefinition(
+                    name=_normalize_name(defn.name),
+                    definitions=fields,
+                    aggregatedKind=AggregatedKind.STRUCT,
+                )
+            )
+        elif isinstance(defn, IDLModuleDefinition):
+            fields = []
+            for field in defn.definitions:
+                f = replace(field)
+                f.type = _normalize_name(f.type)
+                if f.enumType:
+                    f.enumType = _normalize_name(f.enumType)
+                fields.append(f)
+            message_defs.append(
+                MessageDefinition(
+                    name=_normalize_name(defn.name),
+                    definitions=fields,
+                    aggregatedKind=AggregatedKind.MODULE,
+                )
+            )
+        elif isinstance(defn, IDLUnionDefinition):
+            cases: List[UnionCase] = []
+            for case in defn.cases:
+                f = replace(case.type)
+                f.type = _normalize_name(f.type)
+                if f.enumType:
+                    f.enumType = _normalize_name(f.enumType)
+                cases.append(UnionCase(predicates=case.predicates, type=f))
+            default_case = None
+            if defn.defaultCase is not None:
+                f = replace(defn.defaultCase)
+                f.type = _normalize_name(f.type)
+                if f.enumType:
+                    f.enumType = _normalize_name(f.enumType)
+                default_case = f
+            message_defs.append(
+                MessageDefinition(
+                    name=_normalize_name(defn.name),
+                    aggregatedKind=AggregatedKind.UNION,
+                    switchType=_normalize_name(defn.switchType),
+                    cases=cases,
+                    defaultCase=default_case,
+                )
+            )
+
+    for msg in message_defs:
+        if msg.name in (
+            "builtin_interfaces/msg/Time",
+            "builtin_interfaces/msg/Duration",
+        ):
+            for field in msg.definitions:
+                if field.name == "nanosec":
+                    field.name = "nsec"
+
+    return message_defs
+
+
+def _normalize_name(name: str) -> str:
+    s = str(name)
+    return s.replace("::", "/") if "::" in s else s
+
+
+__all__ = [
+    "parse_ros2idl",
+    "AggregatedKind",
+    "MessageDefinition",
+    "MessageDefinitionField",
+]

--- a/mcap_ros2idl_support/rosmsg/__init__.py
+++ b/mcap_ros2idl_support/rosmsg/__init__.py
@@ -1,0 +1,5 @@
+from mcap_ros2idl_support.rosmsg.md5 import md5
+from mcap_ros2idl_support.rosmsg.parse import fixup_types, normalize_type, parse
+from mcap_ros2idl_support.rosmsg.stringify import stringify
+
+__all__ = ["parse", "stringify", "fixup_types", "normalize_type", "md5"]

--- a/mcap_ros2idl_support/rosmsg/md5.py
+++ b/mcap_ros2idl_support/rosmsg/md5.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Dict, List
+
+from mcap_ros2idl_support.message_definition import MessageDefinition
+
+BUILTIN_TYPES = {
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "int64",
+    "uint64",
+    "float32",
+    "float64",
+    "string",
+    "bool",
+    "char",
+    "byte",
+    "time",
+    "duration",
+}
+
+
+def md5(msg_defs: List[MessageDefinition]) -> str:
+    if not msg_defs:
+        raise ValueError("Cannot produce md5sum for empty msgDefs")
+    sub_defs: Dict[str, MessageDefinition] = {
+        d.name: d for d in msg_defs if d.name is not None
+    }
+    first = msg_defs[0]
+    return _compute_md5(first, sub_defs)
+
+
+def _compute_md5(
+    msg_def: MessageDefinition, sub_defs: Dict[str, MessageDefinition]
+) -> str:
+    constants = [d for d in msg_def.definitions if d.isConstant]
+    variables = [d for d in msg_def.definitions if not d.isConstant]
+    lines: List[str] = []
+    for d in constants:
+        valueText = d.valueText if d.valueText is not None else str(d.value)
+        lines.append(f"{d.type} {d.name}={valueText}")
+    for d in variables:
+        if _is_builtin(d.type):
+            array_len = str(d.arrayLength) if d.arrayLength is not None else ""
+            array = f"[{array_len}]" if d.isArray else ""
+            lines.append(f"{d.type}{array} {d.name}")
+        else:
+            sub = sub_defs.get(d.type)
+            if sub is None:
+                raise ValueError(f'Missing definition for submessage type "{d.type}"')
+            sub_md5 = _compute_md5(sub, sub_defs)
+            lines.append(f"{sub_md5} {d.name}")
+    text = "\n".join(lines)
+    return hashlib.md5(text.encode()).hexdigest()
+
+
+def _is_builtin(type_name: str) -> bool:
+    return type_name in BUILTIN_TYPES

--- a/mcap_ros2idl_support/rosmsg/parse.py
+++ b/mcap_ros2idl_support/rosmsg/parse.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import re
+from typing import List, Optional
+
+from mcap_ros2idl_support.message_definition import (
+    MessageDefinition,
+    MessageDefinitionField,
+    is_msg_def_equal,
+)
+
+BUILTIN_TYPES = {
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "int64",
+    "uint64",
+    "float32",
+    "float64",
+    "string",
+    "bool",
+    "char",
+    "byte",
+    "time",
+    "duration",
+}
+
+
+ROS2_BUILTIN_TYPES = {
+    "bool",
+    "byte",
+    "char",
+    "float32",
+    "float64",
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "int64",
+    "uint64",
+    "string",
+    "wstring",
+    "time",
+    "duration",
+    "builtin_interfaces/Time",
+    "builtin_interfaces/Duration",
+    "builtin_interfaces/msg/Time",
+    "builtin_interfaces/msg/Duration",
+}
+
+TYPE = r"(?P<type>[a-zA-Z0-9_/]+)"
+STRING_BOUND = r"(?:<=(?P<stringBound>\d+))"
+ARRAY_BOUND = (
+    r"(?:(?P<unboundedArray>\[\])|\[(?P<arrayLength>\d+)\]|\[<=(?P<arrayBound>\d+)\])"
+)
+NAME = r"(?P<name>[a-zA-Z0-9_]+)"
+QUOTED_STRING = r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\""
+COMMENT_TERMINATED_LITERAL = (
+    r"(?:" + QUOTED_STRING + r"|(?:\\.|[^\s'\"#\\])(?:\\.|[^#\\])*)"
+)
+ARRAY_TERMINATED_LITERAL = (
+    r"(?:" + QUOTED_STRING + r"|(?:\\.|[^\s'\"\],#\\])(?:\\.|[^\],#\\])*)"
+)
+CONSTANT_ASSIGNMENT = r"\s*=\s*(?P<constantValue>" + COMMENT_TERMINATED_LITERAL + r"?)"
+DEFAULT_VALUE_ARRAY = (
+    r"\[(?:" + ARRAY_TERMINATED_LITERAL + r",)*" + ARRAY_TERMINATED_LITERAL + r"?\]"
+)
+DEFAULT_VALUE = (
+    r"(?P<defaultValue>"
+    + DEFAULT_VALUE_ARRAY
+    + r"|"
+    + COMMENT_TERMINATED_LITERAL
+    + r")"
+)
+COMMENT = r"(?:#.*)"
+DEFINITION_LINE_REGEX = re.compile(
+    r"^"
+    + TYPE
+    + STRING_BOUND
+    + r"?"
+    + ARRAY_BOUND
+    + r"?\s+"
+    + NAME
+    + r"(?:"
+    + CONSTANT_ASSIGNMENT
+    + r"|\s+"
+    + DEFAULT_VALUE
+    + r")?\s*"
+    + COMMENT
+    + r"?$"
+)
+
+STRING_ESCAPES = (
+    r"\\(?P<char>['\"abfnrtv\\])|\\(?P<oct>[0-7]{1,3})|"
+    r"\\x(?P<hex2>[a-fA-F0-9]{2})|\\u(?P<hex4>[a-fA-F0-9]{4})|"
+    r"\\U(?P<hex8>[a-fA-F0-9]{8})"
+)
+
+LITERAL_REGEX = re.compile(ARRAY_TERMINATED_LITERAL)
+COMMA_OR_END_REGEX = re.compile(r"\s*(,)?\s*|\s*$")
+
+
+def _parse_big_int_literal(text: str, min_value: int, max_value: int) -> int:
+    value = int(text)
+    if value < min_value or value > max_value:
+        raise ValueError(f"Number {text} out of range [{min_value}, {max_value}]")
+    return value
+
+
+def _parse_number_literal(text: str, min_value: int, max_value: int) -> int:
+    try:
+        value = int(text)
+    except ValueError:
+        raise ValueError(f"Invalid numeric literal: {text}")
+    if value < min_value or value > max_value:
+        raise ValueError(f"Number {text} out of range [{min_value}, {max_value}]")
+    return value
+
+
+def _parse_string_literal(maybe_quoted: str) -> str:
+    quote = ""
+    s = maybe_quoted
+    for q in ("'", '"'):
+        if s.startswith(q):
+            if not s.endswith(q):
+                raise ValueError(
+                    f"Expected terminating {q} in string literal: {maybe_quoted}"
+                )
+            quote = q
+            s = s[len(q) : -len(q)]
+            break
+    pattern = rf"^(?:[^\\{quote}]|{STRING_ESCAPES})*$"
+    if re.fullmatch(pattern, s) is None:
+        raise ValueError(f"Invalid string literal: {s}")
+
+    def replace(match: re.Match) -> str:
+        groups = match.groupdict()
+        if groups.get("char"):
+            return {
+                "'": "'",
+                '"': '"',
+                "a": "\x07",
+                "b": "\b",
+                "f": "\f",
+                "n": "\n",
+                "r": "\r",
+                "t": "\t",
+                "v": "\v",
+                "\\": "\\",
+            }[groups["char"]]
+        if groups.get("oct"):
+            return chr(int(groups["oct"], 8))
+        hex_val = groups.get("hex2") or groups.get("hex4") or groups.get("hex8")
+        if hex_val:
+            return chr(int(hex_val, 16))
+        raise ValueError("Expected exactly one matched group")
+
+    return re.sub(STRING_ESCAPES, replace, s)
+
+
+def _parse_primitive_literal(type_name: str, text: str):
+    if type_name == "bool":
+        if text in {"true", "True", "1"}:
+            return True
+        if text in {"false", "False", "0"}:
+            return False
+    elif type_name in {"float32", "float64"}:
+        value = float(text)
+        if value == value:  # not NaN
+            return value
+    elif type_name == "int8":
+        return _parse_number_literal(text, -0x80, 0x7F)
+    elif type_name == "uint8":
+        return _parse_number_literal(text, 0, 0xFF)
+    elif type_name == "int16":
+        return _parse_number_literal(text, -0x8000, 0x7FFF)
+    elif type_name == "uint16":
+        return _parse_number_literal(text, 0, 0xFFFF)
+    elif type_name == "int32":
+        return _parse_number_literal(text, -0x80000000, 0x7FFFFFFF)
+    elif type_name == "uint32":
+        return _parse_number_literal(text, 0, 0xFFFFFFFF)
+    elif type_name == "int64":
+        return _parse_big_int_literal(text, -0x8000000000000000, 0x7FFFFFFFFFFFFFFF)
+    elif type_name == "uint64":
+        return _parse_big_int_literal(text, 0, 0xFFFFFFFFFFFFFFFF)
+    elif type_name in {"string", "wstring"}:
+        return _parse_string_literal(text)
+    raise ValueError(f"Invalid literal of type {type_name}: {text}")
+
+
+def _parse_array_literal(type_name: str, raw: str):
+    if not raw.startswith("[") or not raw.endswith("]"):
+        raise ValueError("Array must start with [ and end with ]")
+    inner = raw[1:-1]
+    if type_name in {"string", "wstring"}:
+        results = []
+        offset = 0
+        while offset < len(inner):
+            if inner[offset] == ",":
+                raise ValueError("Expected array element before comma")
+            m = LITERAL_REGEX.match(inner, offset)
+            if m:
+                results.append(_parse_string_literal(m.group(0)))
+                offset = m.end()
+            m = COMMA_OR_END_REGEX.match(inner, offset)
+            if not m:
+                raise ValueError("Expected comma or end of array")
+            if not m.group(1):
+                break
+            offset = m.end()
+        return results
+    return [
+        _parse_primitive_literal(type_name, part.strip())
+        for part in inner.split(",")
+        if part.strip() != ""
+    ]
+
+
+def _normalize_type_ros2(type_name: str) -> str:
+    if type_name in {"char", "byte"}:
+        return "uint8"
+    if type_name in {"builtin_interfaces/Time", "builtin_interfaces/msg/Time"}:
+        return "time"
+    if type_name in {"builtin_interfaces/Duration", "builtin_interfaces/msg/Duration"}:
+        return "duration"
+    return type_name
+
+
+def _build_ros2_type(lines: List[str]) -> MessageDefinition:
+    definitions: List[MessageDefinitionField] = []
+    complex_type_name: Optional[str] = None
+    for line in lines:
+        if line.startswith("#"):
+            continue
+        m_msg = re.match(r"^MSG: ([^ ]+)\s*(?:#.+)?$", line)
+        if m_msg:
+            complex_type_name = m_msg.group(1)
+            continue
+        m = DEFINITION_LINE_REGEX.match(line)
+        if not m:
+            raise ValueError(f"Could not parse line: '{line}'")
+        groups = m.groupdict()
+        raw_type = groups["type"]
+        type_name = _normalize_type_ros2(raw_type)
+        string_bound = groups.get("stringBound")
+        unbounded_array = groups.get("unboundedArray")
+        array_length = groups.get("arrayLength")
+        array_bound = groups.get("arrayBound")
+        name = groups["name"]
+        constant_value = groups.get("constantValue")
+        default_value = groups.get("defaultValue")
+
+        if string_bound is not None and type_name not in {"string", "wstring"}:
+            raise ValueError(f"Invalid string bound for type {type_name}")
+        if constant_value is not None:
+            if re.fullmatch(r"[A-Z](?:_?[A-Z0-9]+)*", name) is None:
+                raise ValueError(f"Invalid constant name: {name}")
+        else:
+            if re.fullmatch(r"[a-z](?:_?[a-z0-9]+)*", name) is None:
+                raise ValueError(f"Invalid field name: {name}")
+
+        is_complex = type_name not in ROS2_BUILTIN_TYPES
+        is_array = bool(unbounded_array or array_length or array_bound)
+
+        field = MessageDefinitionField(
+            name=name,
+            type=type_name,
+            isComplex=is_complex,
+            isArray=is_array,
+            arrayLength=int(array_length) if array_length else None,
+            arrayUpperBound=int(array_bound) if array_bound else None,
+            upperBound=int(string_bound) if string_bound else None,
+            isConstant=constant_value is not None,
+            defaultValue=(
+                _parse_array_literal(type_name, default_value.strip())
+                if default_value is not None and is_array
+                else (
+                    _parse_primitive_literal(type_name, default_value.strip())
+                    if default_value is not None
+                    else None
+                )
+            ),
+            value=(
+                _parse_primitive_literal(type_name, constant_value.strip())
+                if constant_value is not None
+                else None
+            ),
+            valueText=constant_value.strip() if constant_value is not None else None,
+        )
+        definitions.append(field)
+    return MessageDefinition(name=complex_type_name, definitions=definitions)
+
+
+def parse(
+    message_definition: str, ros2: bool = False, skip_type_fixup: bool = False
+) -> List[MessageDefinition]:
+    lines = [line.strip() for line in message_definition.splitlines() if line.strip()]
+    definition_lines: List[str] = []
+    types: List[MessageDefinition] = []
+    for line in lines:
+        if line.startswith("#"):
+            continue
+        if line.startswith("=="):
+            types.append(
+                _build_ros2_type(definition_lines)
+                if ros2
+                else _build_type(definition_lines)
+            )
+            definition_lines = []
+        else:
+            definition_lines.append(line)
+    types.append(
+        _build_ros2_type(definition_lines) if ros2 else _build_type(definition_lines)
+    )
+
+    unique: List[MessageDefinition] = []
+    for t in types:
+        if not any(is_msg_def_equal(t, other) for other in unique):
+            unique.append(t)
+
+    if not skip_type_fixup:
+        fixup_types(unique)
+
+    return unique
+
+
+def fixup_types(types: List[MessageDefinition]) -> None:
+    for msg in types:
+        namespace = "/".join(msg.name.split("/")[:-1]) if msg.name else None
+        for field in msg.definitions:
+            if field.isComplex:
+                found = _find_type_by_name(types, field.type, namespace)
+                if found.name is None:
+                    raise ValueError(f"Missing type definition for {field.type}")
+                field.type = found.name
+
+
+def _build_type(lines: List[str]) -> MessageDefinition:
+    definitions: List[MessageDefinitionField] = []
+    complex_type_name: Optional[str] = None
+    for line in lines:
+        if line.startswith("MSG:"):
+            complex_type_name = line.split(":", 1)[1].strip()
+            continue
+        line = re.sub(r"#.*", "", line).strip()
+        if not line:
+            continue
+        m = re.match(
+            r"(?P<type>[^\s]+)\s+(?P<name>[^\s=]+)(\s*=\s*(?P<value>.*))?", line
+        )
+        if not m:
+            raise ValueError(f"Could not parse line: '{line}'")
+        type_name = normalize_type(m.group("type"))
+        name = m.group("name")
+        value_text = m.group("value")
+        is_array = False
+        array_length: Optional[int] = None
+        array_match = re.match(r"^(?P<base>[^\[]+)\[(?P<len>\d*)\]$", type_name)
+        if array_match:
+            type_name = array_match.group("base")
+            is_array = True
+            length = array_match.group("len")
+            if length:
+                array_length = int(length)
+        isComplex = not _is_builtin(type_name)
+        field = MessageDefinitionField(
+            type=type_name,
+            name=name,
+            isArray=is_array,
+            arrayLength=array_length,
+            isConstant=value_text is not None,
+            valueText=value_text.strip() if value_text is not None else None,
+            isComplex=isComplex,
+        )
+        definitions.append(field)
+    return MessageDefinition(name=complex_type_name, definitions=definitions)
+
+
+def _find_type_by_name(
+    types: List[MessageDefinition], name: str, type_namespace: Optional[str]
+) -> MessageDefinition:
+    matches: List[MessageDefinition] = []
+    for t in types:
+        type_name = t.name or ""
+        if not name:
+            if not type_name:
+                matches.append(t)
+        elif "/" in name:
+            if type_name == name:
+                matches.append(t)
+        elif name == "Header":
+            if type_name == "std_msgs/Header":
+                matches.append(t)
+        elif type_namespace:
+            if type_name == f"{type_namespace}/{name}":
+                matches.append(t)
+        else:
+            if type_name.endswith(f"/{name}"):
+                matches.append(t)
+    if not matches:
+        raise ValueError(
+            f"Expected 1 top level type definition for '{name}' "
+            f"but found {len(matches)}"
+        )
+    if len(matches) > 1:
+        raise ValueError(
+            f"Cannot unambiguously determine fully-qualified type name for '{name}'"
+        )
+    return matches[0]
+
+
+def normalize_type(type_name: str) -> str:
+    if type_name == "char":
+        return "uint8"
+    if type_name == "byte":
+        return "int8"
+    return type_name
+
+
+def _is_builtin(type_name: str) -> bool:
+    return type_name in BUILTIN_TYPES

--- a/mcap_ros2idl_support/rosmsg/stringify.py
+++ b/mcap_ros2idl_support/rosmsg/stringify.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+from mcap_ros2idl_support.message_definition import MessageDefinition
+
+
+def _stringify_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, float):
+        return format(value, "g")
+    return str(value)
+
+
+def stringify_default_value(value: Any) -> str:
+    if isinstance(value, list):
+        return "[" + ", ".join(_stringify_value(x) for x in value) + "]"
+    return _stringify_value(value)
+
+
+def stringify(msg_defs: List[MessageDefinition]) -> str:
+    lines: List[str] = []
+    for i, msg_def in enumerate(msg_defs):
+        constants = [d for d in msg_def.definitions if getattr(d, "isConstant", False)]
+        variables = [
+            d for d in msg_def.definitions if not getattr(d, "isConstant", False)
+        ]
+
+        if i > 0:
+            lines.append("")
+            lines.append("=" * 80)
+            lines.append(f"MSG: {msg_def.name or ''}")
+        for const in constants:
+            value = (
+                const.valueText
+                if const.valueText is not None
+                else _stringify_value(const.value)
+            )
+            lines.append(f"{const.type} {const.name} = {value}")
+        if variables:
+            if lines:
+                lines.append("")
+            for var in variables:
+                upper_bound = (
+                    f"<={var.upperBound}" if var.upperBound is not None else ""
+                )
+                if var.arrayLength is not None:
+                    array_len = str(var.arrayLength)
+                elif var.arrayUpperBound is not None:
+                    array_len = f"<={var.arrayUpperBound}"
+                else:
+                    array_len = ""
+                array_suffix = (
+                    f"[{array_len}]" if getattr(var, "isArray", False) else ""
+                )
+                default_value = (
+                    f" {stringify_default_value(var.defaultValue)}"
+                    if var.defaultValue is not None
+                    else ""
+                )
+                lines.append(
+                    f"{var.type}{upper_bound}{array_suffix} {var.name}{default_value}"
+                )
+    return "\n".join(lines).rstrip()

--- a/mcap_ros2idl_support/rosmsg2_serialization/MessageReader.py
+++ b/mcap_ros2idl_support/rosmsg2_serialization/MessageReader.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, Sequence
+
+from mcap_ros2idl_support.cdr import CdrReader
+from mcap_ros2idl_support.message_definition import (
+    AggregatedKind,
+    MessageDefinition,
+    MessageDefinitionField,
+)
+from mcap_ros2idl_support.rosmsg2_serialization.message_definition_has_data_fields import (  # noqa: E501
+    message_definition_has_data_fields,
+)
+
+Ros2Time = Dict[str, int]
+Ros1Time = Dict[str, int]
+
+Deserializer = Callable[[CdrReader], Any]
+ArrayDeserializer = Callable[[CdrReader, int], Any]
+
+
+@dataclass
+class MessageReaderOptions:
+    timeType: str = "sec,nanosec"  # "sec,nanosec" or "sec,nsec"
+    enumAsString: bool = False
+
+
+class MessageReader:
+    _root_definition: MessageDefinition
+    _definitions: Mapping[str, MessageDefinition]
+    _use_ros1_time: bool
+    _enum_as_string: bool
+    _enum_mappings: Dict[str, Dict[int, str]]
+    _union_enum_mappings: Dict[str, Dict[int, str]]
+
+    def __init__(
+        self,
+        definitions: Sequence[MessageDefinition],
+        options: MessageReaderOptions | None = None,
+    ) -> None:
+        opts = options or MessageReaderOptions()
+        time_type = opts.timeType
+        self._enum_as_string = opts.enumAsString
+
+        # ros2idl modules could have constant modules before the root struct used
+        # to decode message
+        root_definition = next(
+            (
+                d
+                for d in definitions
+                if d.aggregatedKind == AggregatedKind.STRUCT
+                and not _is_constant_module(d)
+            ),
+            None,
+        )
+        if root_definition is None:
+            root_definition = next(
+                (d for d in definitions if not _is_constant_module(d)), None
+            )
+        if root_definition is None:
+            raise ValueError("MessageReader initialized with no root MessageDefinition")
+        self._root_definition = root_definition
+        self._definitions = {d.name or "": d for d in definitions}
+        self._use_ros1_time = time_type == "sec,nsec"
+
+        # Build enum mappings
+        enum_defns: Dict[str, Dict[int, str]] = {}
+        for d in definitions:
+            if _is_constant_module(d):
+                mapping: Dict[int, str] = {}
+                for f in d.definitions:
+                    if isinstance(f.value, int):
+                        mapping[f.value] = f.name
+                if mapping:
+                    enum_defns[d.name or ""] = mapping
+
+        self._enum_mappings = enum_defns
+
+        self._union_enum_mappings = {}
+        for d in definitions:
+            if d.aggregatedKind != AggregatedKind.UNION:
+                continue
+            case_values: set[int] = set()
+            for c in d.cases:
+                preds = c.predicates
+                if preds:
+                    case_values.update(preds)
+            prefix = (d.name or "").rsplit("/", 1)[0]
+            mapping = None
+            for name, enum_map in enum_defns.items():
+                if prefix and not name.startswith(prefix):
+                    continue
+                if case_values.issubset(enum_map.keys()):
+                    mapping = enum_map
+                    break
+            if mapping is not None:
+                self._union_enum_mappings[d.name or ""] = mapping
+
+    def read_message(self, buffer: bytes | bytearray | memoryview) -> Any:
+        reader = CdrReader(buffer)
+        return self._read_complex_type(self._root_definition, reader)
+
+    def _map_enum(self, value: Any, enum_type: str | None) -> Any:
+        if not (self._enum_as_string and enum_type):
+            return value
+        enum_map = self._enum_mappings.get(enum_type)
+        if enum_map is None:
+            return value
+        if isinstance(value, list):
+            return [enum_map.get(v, v) for v in value]
+        return enum_map.get(value, value)
+
+    def _read_complex_type(
+        self, definition: MessageDefinition, reader: CdrReader
+    ) -> Dict[str, Any]:
+        msg: Dict[str, Any] = {}
+        fields = definition.definitions
+
+        if (
+            definition.aggregatedKind != AggregatedKind.UNION
+            and not message_definition_has_data_fields(fields)
+        ):
+            # In case a message definition definition is empty, ROS 2 adds a
+            # `uint8 structure_needs_at_least_one_member` field when converting to IDL,
+            # to satisfy the requirement from IDL of not being empty.
+            reader.uint8()
+            return msg
+
+        if definition.aggregatedKind == AggregatedKind.UNION:
+            deser_map = _ros1_deserializers if self._use_ros1_time else _deserializers
+            switch_deser = deser_map.get(definition.switchType or "")
+            if switch_deser is None:
+                raise ValueError(
+                    "Unrecognized primitive type "
+                    f"{definition.switchType} for union discriminant"
+                )
+            discr = switch_deser(reader)
+            enum_map = self._union_enum_mappings.get(definition.name or "")
+            if self._enum_as_string and enum_map:
+                msg["discriminator"] = enum_map.get(discr, discr)
+            else:
+                msg["discriminator"] = discr
+
+            field = _union_case_field(definition, discr)
+            if field is None:
+                raise ValueError(f"No union field matches discriminant {discr}")
+            if field.isComplex is True:
+                nested_definition = self._definitions.get(field.type)
+                if nested_definition is None:
+                    raise ValueError(f"Unrecognized complex type {field.type}")
+                if field.isArray is True:
+                    array_length = field.arrayLength or reader.sequence_length()
+                    array = []
+                    for _ in range(array_length):
+                        array.append(self._read_complex_type(nested_definition, reader))
+                    msg[field.name] = array
+                else:
+                    msg[field.name] = self._read_complex_type(nested_definition, reader)
+            else:
+                if field.isArray is True:
+                    deser_map = (
+                        _ros1_typed_array_deserializers
+                        if self._use_ros1_time
+                        else _typed_array_deserializers
+                    )
+                    deser = deser_map.get(field.type)
+                    if deser is None:
+                        raise ValueError(
+                            f"Unrecognized primitive array type {field.type}[]"
+                        )
+                    array_length = field.arrayLength or reader.sequence_length()
+                    value = deser(reader, array_length)
+                    msg[field.name] = self._map_enum(value, field.enumType)
+                else:
+                    deser_map = (
+                        _ros1_deserializers if self._use_ros1_time else _deserializers
+                    )
+                    deser = deser_map.get(field.type)
+                    if deser is None:
+                        raise ValueError(f"Unrecognized primitive type {field.type}")
+                    value = deser(reader)
+                    msg[field.name] = self._map_enum(value, field.enumType)
+            return msg
+
+        for field in fields:
+            if field.isConstant is True:
+                continue
+
+            if field.isComplex is True:
+                nested_definition = self._definitions.get(field.type)
+                if nested_definition is None:
+                    raise ValueError(f"Unrecognized complex type {field.type}")
+                if field.isArray is True:
+                    array_length = field.arrayLength or reader.sequence_length()
+                    array = []
+                    for _ in range(array_length):
+                        array.append(self._read_complex_type(nested_definition, reader))
+                    msg[field.name] = array
+                else:
+                    msg[field.name] = self._read_complex_type(nested_definition, reader)
+            else:
+                if field.isArray is True:
+                    deser_map = (
+                        _ros1_typed_array_deserializers
+                        if self._use_ros1_time
+                        else _typed_array_deserializers
+                    )
+                    deser = deser_map.get(field.type)
+                    if deser is None:
+                        raise ValueError(
+                            f"Unrecognized primitive array type {field.type}[]"
+                        )
+                    array_length = field.arrayLength or reader.sequence_length()
+                    value = deser(reader, array_length)
+                    msg[field.name] = self._map_enum(value, field.enumType)
+                else:
+                    deser_map = (
+                        _ros1_deserializers if self._use_ros1_time else _deserializers
+                    )
+                    deser = deser_map.get(field.type)
+                    if deser is None:
+                        raise ValueError(f"Unrecognized primitive type {field.type}")
+                    value = deser(reader)
+                    msg[field.name] = self._map_enum(value, field.enumType)
+
+        return msg
+
+
+def _is_constant_module(defn: MessageDefinition) -> bool:
+    return len(defn.definitions) > 0 and all(f.isConstant for f in defn.definitions)
+
+
+def _union_case_field(
+    defn: MessageDefinition, discriminator: Any
+) -> MessageDefinitionField | None:
+    """Return the field for ``discriminator`` from ``defn``."""
+
+    for case in defn.cases:
+        if case.predicates and discriminator in case.predicates:
+            return case.type
+
+    return defn.defaultCase
+
+
+def _read_bool_array(reader: CdrReader, count: int) -> List[bool]:
+    return [bool(reader.int8()) for _ in range(count)]
+
+
+def _read_string_array(reader: CdrReader, count: int) -> List[str]:
+    return [reader.string() for _ in range(count)]
+
+
+def _read_ros1_time_array(reader: CdrReader, count: int) -> List[Ros1Time]:
+    array: List[Ros1Time] = []
+    for _ in range(count):
+        sec = reader.int32()
+        nsec = reader.uint32()
+        array.append({"sec": sec, "nsec": nsec})
+    return array
+
+
+def _read_time_array(reader: CdrReader, count: int) -> List[Ros2Time]:
+    array: List[Ros2Time] = []
+    for _ in range(count):
+        sec = reader.int32()
+        nanosec = reader.uint32()
+        array.append({"sec": sec, "nanosec": nanosec})
+    return array
+
+
+def _throw_on_wstring(*_: Any) -> None:
+    raise RuntimeError("wstring is implementation-defined and therefore not supported")
+
+
+_deserializers: Dict[str, Deserializer] = {
+    "bool": lambda r: bool(r.int8()),
+    "int8": lambda r: r.int8(),
+    "uint8": lambda r: r.uint8(),
+    "int16": lambda r: r.int16(),
+    "uint16": lambda r: r.uint16(),
+    "int32": lambda r: r.int32(),
+    "uint32": lambda r: r.uint32(),
+    "int64": lambda r: r.int64(),
+    "uint64": lambda r: r.uint64(),
+    "float32": lambda r: r.float32(),
+    "float64": lambda r: r.float64(),
+    "string": lambda r: r.string(),
+    "wstring": _throw_on_wstring,
+    "time": lambda r: {"sec": r.int32(), "nanosec": r.uint32()},
+    "duration": lambda r: {"sec": r.int32(), "nanosec": r.uint32()},
+}
+
+_ros1_deserializers: Dict[str, Deserializer] = {
+    **_deserializers,
+    "time": lambda r: {"sec": r.int32(), "nsec": r.uint32()},
+    "duration": lambda r: {"sec": r.int32(), "nsec": r.uint32()},
+}
+
+_typed_array_deserializers: Dict[str, ArrayDeserializer] = {
+    "bool": _read_bool_array,
+    "int8": lambda r, c: r.int8_array(c).tolist(),
+    "uint8": lambda r, c: r.uint8_array(c).tolist(),
+    "int16": lambda r, c: r.int16_array(c).tolist(),
+    "uint16": lambda r, c: r.uint16_array(c).tolist(),
+    "int32": lambda r, c: r.int32_array(c).tolist(),
+    "uint32": lambda r, c: r.uint32_array(c).tolist(),
+    "int64": lambda r, c: r.int64_array(c).tolist(),
+    "uint64": lambda r, c: r.uint64_array(c).tolist(),
+    "float32": lambda r, c: r.float32_array(c).tolist(),
+    "float64": lambda r, c: r.float64_array(c).tolist(),
+    "string": _read_string_array,
+    "wstring": _throw_on_wstring,
+    "time": _read_time_array,
+    "duration": _read_time_array,
+}
+
+_ros1_typed_array_deserializers: Dict[str, ArrayDeserializer] = {
+    **_typed_array_deserializers,
+    "time": _read_ros1_time_array,
+    "duration": _read_ros1_time_array,
+}
+
+__all__ = ["MessageReader", "MessageReaderOptions"]

--- a/mcap_ros2idl_support/rosmsg2_serialization/MessageWriter.py
+++ b/mcap_ros2idl_support/rosmsg2_serialization/MessageWriter.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Mapping, Sequence
+
+from mcap_ros2idl_support.cdr import CdrWriter
+from mcap_ros2idl_support.message_definition import (
+    DefaultValue,
+    MessageDefinition,
+    MessageDefinitionField,
+)
+from mcap_ros2idl_support.rosmsg2_serialization.message_definition_has_data_fields import (  # noqa: E501
+    message_definition_has_data_fields,
+)
+
+PrimitiveWriter = Callable[[Any, DefaultValue, CdrWriter, int | None], None]
+PrimitiveArrayWriter = Callable[[Any, DefaultValue, CdrWriter, int | None], None]
+
+PRIMITIVE_SIZES: Dict[str, int] = {
+    "bool": 1,
+    "int8": 1,
+    "uint8": 1,
+    "int16": 2,
+    "uint16": 2,
+    "int32": 4,
+    "uint32": 4,
+    "int64": 8,
+    "uint64": 8,
+    "float32": 4,
+    "float64": 8,
+    # string handled separately
+    "time": 8,
+    "duration": 8,
+}
+
+
+class MessageWriter:
+    _root_definition: List[MessageDefinitionField]
+    _definitions: Mapping[str, List[MessageDefinitionField]]
+
+    def __init__(self, definitions: Sequence[MessageDefinition]) -> None:
+        root_definition = next(
+            (d for d in definitions if not _is_constant_module(d)), None
+        )
+        if root_definition is None:
+            raise ValueError("MessageReader initialized with no root MessageDefinition")
+        self._root_definition = list(root_definition.definitions)
+        self._definitions = {d.name or "": list(d.definitions) for d in definitions}
+
+    def calculate_byte_size(self, message: Any) -> int:
+        return self._byte_size(self._root_definition, message, 4)
+
+    def write_message(self, message: Any, output: bytearray | None = None) -> bytes:
+        writer = CdrWriter(
+            buffer=output,
+            size=None if output is not None else self.calculate_byte_size(message),
+        )
+        self._write(self._root_definition, message, writer)
+        return writer.data
+
+    def _byte_size(
+        self, definition: Sequence[MessageDefinitionField], message: Any, offset: int
+    ) -> int:
+        message_obj = message if isinstance(message, dict) else {}
+        new_offset = offset
+
+        if not message_definition_has_data_fields(definition):
+            return offset + self._get_primitive_size("uint8")
+
+        for field in definition:
+            if field.isConstant is True:
+                continue
+            nested_message = (
+                message_obj.get(field.name) if isinstance(message_obj, dict) else None
+            )
+            if field.isArray is True:
+                array_length = field.arrayLength or _field_length(nested_message)
+                data_is_array = isinstance(nested_message, (list, tuple))
+                data_array = list(nested_message) if data_is_array else []
+                if field.arrayLength is None:
+                    new_offset += _padding(new_offset, 4)
+                    new_offset += 4
+                if field.isComplex is True:
+                    nested_definition = self._get_definition(field.type)
+                    for i in range(array_length):
+                        entry = data_array[i] if i < len(data_array) else {}
+                        new_offset = self._byte_size(
+                            nested_definition, entry, new_offset
+                        )
+                elif field.type == "string":
+                    for i in range(array_length):
+                        entry = data_array[i] if i < len(data_array) else ""
+                        new_offset += _padding(new_offset, 4)
+                        new_offset += 4 + len(entry) + 1
+                else:
+                    entry_size = self._get_primitive_size(field.type)
+                    alignment = 4 if field.type in {"time", "duration"} else entry_size
+                    new_offset += _padding(new_offset, alignment)
+                    new_offset += entry_size * array_length
+            else:
+                if field.isComplex is True:
+                    nested_definition = self._get_definition(field.type)
+                    entry = nested_message if isinstance(nested_message, dict) else {}
+                    new_offset = self._byte_size(nested_definition, entry, new_offset)
+                elif field.type == "string":
+                    entry = nested_message if isinstance(nested_message, str) else ""
+                    new_offset += _padding(new_offset, 4)
+                    new_offset += 4 + len(entry) + 1
+                else:
+                    entry_size = self._get_primitive_size(field.type)
+                    alignment = 4 if field.type in {"time", "duration"} else entry_size
+                    new_offset += _padding(new_offset, alignment)
+                    new_offset += entry_size
+        return new_offset
+
+    def _write(
+        self,
+        definition: Sequence[MessageDefinitionField],
+        message: Any,
+        writer: CdrWriter,
+    ) -> None:
+        message_obj = message if isinstance(message, dict) else {}
+
+        if not message_definition_has_data_fields(definition):
+            _uint8(0, 0, writer)
+            return
+
+        for field in definition:
+            if field.isConstant is True:
+                continue
+
+            nested_message = (
+                message_obj.get(field.name) if isinstance(message_obj, dict) else None
+            )
+
+            if field.isArray is True:
+                array_length = field.arrayLength or _field_length(nested_message)
+                data_is_array = isinstance(nested_message, (list, tuple))
+                data_array = list(nested_message) if data_is_array else []
+                if field.arrayLength is None:
+                    writer.sequenceLength(array_length)
+                if field.arrayLength is not None and nested_message is not None:
+                    given_length = _field_length(nested_message)
+                    if given_length != field.arrayLength:
+                        raise ValueError(
+                            "Expected {exp} items for fixed-length array field {name} "
+                            "but received {got}".format(
+                                exp=field.arrayLength,
+                                name=field.name,
+                                got=given_length,
+                            )
+                        )
+                if field.isComplex is True:
+                    nested_definition = self._get_definition(field.type)
+                    for i in range(array_length):
+                        entry = data_array[i] if i < len(data_array) else {}
+                        self._write(nested_definition, entry, writer)
+                else:
+                    array_writer = self._get_primitive_array_writer(field.type)
+                    array_writer(
+                        nested_message, field.defaultValue, writer, field.arrayLength
+                    )
+            else:
+                if field.isComplex is True:
+                    nested_definition = self._get_definition(field.type)
+                    entry = nested_message if nested_message is not None else {}
+                    self._write(nested_definition, entry, writer)
+                else:
+                    primitive_writer = self._get_primitive_writer(field.type)
+                    primitive_writer(nested_message, field.defaultValue, writer, None)
+
+    def _get_definition(self, datatype: str) -> List[MessageDefinitionField]:
+        nested = self._definitions.get(datatype)
+        if nested is None:
+            raise ValueError(f"Unrecognized complex type {datatype}")
+        return nested
+
+    def _get_primitive_size(self, primitive_type: str) -> int:
+        size = PRIMITIVE_SIZES.get(primitive_type)
+        if size is None:
+            if primitive_type == "wstring":
+                _throw_on_wstring()
+            raise ValueError(f"Unrecognized primitive type {primitive_type}")
+        return size
+
+    def _get_primitive_writer(self, primitive_type: str) -> PrimitiveWriter:
+        writer = PRIMITIVE_WRITERS.get(primitive_type)
+        if writer is None:
+            raise ValueError(f"Unrecognized primitive type {primitive_type}")
+        return writer
+
+    def _get_primitive_array_writer(self, primitive_type: str) -> PrimitiveArrayWriter:
+        writer = PRIMITIVE_ARRAY_WRITERS.get(primitive_type)
+        if writer is None:
+            raise ValueError(f"Unrecognized primitive type {primitive_type}[]")
+        return writer
+
+
+# Primitive writers
+
+
+def _bool(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    bool_value = (
+        value
+        if isinstance(value, bool)
+        else (default if isinstance(default, bool) else False)
+    )
+    writer.int8(1 if bool_value else 0)
+
+
+def _int8(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    writer.int8(int(value if isinstance(value, (int, float)) else default or 0))
+
+
+def _uint8(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    writer.uint8(int(value if isinstance(value, (int, float)) else default or 0))
+
+
+def _int16(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    writer.int16(int(value if isinstance(value, (int, float)) else default or 0))
+
+
+def _uint16(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    writer.uint16(int(value if isinstance(value, (int, float)) else default or 0))
+
+
+def _int32(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    writer.int32(int(value if isinstance(value, (int, float)) else default or 0))
+
+
+def _uint32(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    writer.uint32(int(value if isinstance(value, (int, float)) else default or 0))
+
+
+def _int64(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    if isinstance(value, int):
+        writer.int64(value)
+    elif isinstance(value, float):
+        writer.int64(int(value))
+    else:
+        writer.int64(int(default or 0))
+
+
+def _uint64(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    if isinstance(value, int):
+        writer.uint64(value)
+    elif isinstance(value, float):
+        writer.uint64(int(value))
+    else:
+        writer.uint64(int(default or 0))
+
+
+def _float32(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    writer.float32(float(value if isinstance(value, (int, float)) else default or 0.0))
+
+
+def _float64(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    writer.float64(float(value if isinstance(value, (int, float)) else default or 0.0))
+
+
+def _string(
+    value: Any, default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    writer.string(str(value if isinstance(value, str) else default or ""))
+
+
+def _time(
+    value: Any, _default: DefaultValue, writer: CdrWriter, _length: int | None = None
+) -> None:
+    if value is None:
+        writer.int32(0)
+        writer.uint32(0)
+        return
+    sec = value.get("sec", 0) if isinstance(value, dict) else 0
+    nsec = value.get("nsec") if isinstance(value, dict) else None
+    nanosec = value.get("nanosec") if isinstance(value, dict) else None
+    writer.int32(int(sec))
+    writer.uint32(int(nsec if nsec is not None else nanosec or 0))
+
+
+def _throw_on_wstring(*_: Any) -> None:
+    raise RuntimeError("wstring is implementation-defined and therefore not supported")
+
+
+def _bool_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        writer.int8Array([1 if bool(v) else 0 for v in value])
+    else:
+        arr = [1 if bool(v) else 0 for v in (default or [False] * (array_length or 0))]
+        writer.int8Array(arr)
+
+
+def _int8_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        writer.int8Array([int(v) for v in value])
+    else:
+        arr = [int(v) for v in (default or [0] * (array_length or 0))]
+        writer.int8Array(arr)
+
+
+def _uint8_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, (bytes, bytearray)):
+        writer.uint8Array(value)
+    elif isinstance(value, Sequence) and not isinstance(value, str):
+        writer.uint8Array([int(v) for v in value])
+    else:
+        arr = [int(v) for v in (default or [0] * (array_length or 0))]
+        writer.uint8Array(arr)
+
+
+def _int16_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        writer.int16Array([int(v) for v in value])
+    else:
+        arr = [int(v) for v in (default or [0] * (array_length or 0))]
+        writer.int16Array(arr)
+
+
+def _uint16_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        writer.uint16Array([int(v) for v in value])
+    else:
+        arr = [int(v) for v in (default or [0] * (array_length or 0))]
+        writer.uint16Array(arr)
+
+
+def _int32_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        writer.int32Array([int(v) for v in value])
+    else:
+        arr = [int(v) for v in (default or [0] * (array_length or 0))]
+        writer.int32Array(arr)
+
+
+def _uint32_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        writer.uint32Array([int(v) for v in value])
+    else:
+        arr = [int(v) for v in (default or [0] * (array_length or 0))]
+        writer.uint32Array(arr)
+
+
+def _int64_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        writer.int64Array([int(v) for v in value])
+    else:
+        arr = [int(v) for v in (default or [0] * (array_length or 0))]
+        writer.int64Array(arr)
+
+
+def _uint64_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        writer.uint64Array([int(v) for v in value])
+    else:
+        arr = [int(v) for v in (default or [0] * (array_length or 0))]
+        writer.uint64Array(arr)
+
+
+def _float32_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        writer.float32Array([float(v) for v in value])
+    else:
+        arr = [float(v) for v in (default or [0.0] * (array_length or 0))]
+        writer.float32Array(arr)
+
+
+def _float64_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        writer.float64Array([float(v) for v in value])
+    else:
+        arr = [float(v) for v in (default or [0.0] * (array_length or 0))]
+        writer.float64Array(arr)
+
+
+def _string_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            writer.string(str(item))
+    else:
+        arr = list(default or [""] * (array_length or 0))
+        for item in arr:
+            writer.string(str(item))
+
+
+def _time_array(
+    value: Any, _default: DefaultValue, writer: CdrWriter, array_length: int | None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            _time(item, None, writer)
+    else:
+        arr = [None] * (array_length or 0)
+        for item in arr:
+            _time(item, None, writer)
+
+
+PRIMITIVE_WRITERS: Dict[str, PrimitiveWriter] = {
+    "bool": _bool,
+    "int8": _int8,
+    "uint8": _uint8,
+    "int16": _int16,
+    "uint16": _uint16,
+    "int32": _int32,
+    "uint32": _uint32,
+    "int64": _int64,
+    "uint64": _uint64,
+    "float32": _float32,
+    "float64": _float64,
+    "string": _string,
+    "time": _time,
+    "duration": _time,
+    "wstring": _throw_on_wstring,
+}
+
+PRIMITIVE_ARRAY_WRITERS: Dict[str, PrimitiveArrayWriter] = {
+    "bool": _bool_array,
+    "int8": _int8_array,
+    "uint8": _uint8_array,
+    "int16": _int16_array,
+    "uint16": _uint16_array,
+    "int32": _int32_array,
+    "uint32": _uint32_array,
+    "int64": _int64_array,
+    "uint64": _uint64_array,
+    "float32": _float32_array,
+    "float64": _float64_array,
+    "string": _string_array,
+    "time": _time_array,
+    "duration": _time_array,
+    "wstring": _throw_on_wstring,
+}
+
+
+def _field_length(value: Any) -> int:
+    length = getattr(value, "__len__", None)
+    return (
+        int(length())
+        if callable(length)
+        else (len(value) if isinstance(value, Sequence) else 0)
+    )
+
+
+def _padding(offset: int, byte_width: int) -> int:
+    alignment = (offset - 4) % byte_width
+    return byte_width - alignment if alignment > 0 else 0
+
+
+def _is_constant_module(defn: MessageDefinition) -> bool:
+    return len(defn.definitions) > 0 and all(f.isConstant for f in defn.definitions)
+
+
+__all__ = ["MessageWriter"]

--- a/mcap_ros2idl_support/rosmsg2_serialization/__init__.py
+++ b/mcap_ros2idl_support/rosmsg2_serialization/__init__.py
@@ -1,0 +1,7 @@
+from mcap_ros2idl_support.rosmsg2_serialization.MessageReader import (
+    MessageReader,
+    MessageReaderOptions,
+)
+from mcap_ros2idl_support.rosmsg2_serialization.MessageWriter import MessageWriter
+
+__all__ = ["MessageReader", "MessageReaderOptions", "MessageWriter"]

--- a/mcap_ros2idl_support/rosmsg2_serialization/message_definition_has_data_fields.py
+++ b/mcap_ros2idl_support/rosmsg2_serialization/message_definition_has_data_fields.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from mcap_ros2idl_support.message_definition import MessageDefinitionField
+
+
+def message_definition_has_data_fields(
+    fields: Sequence[MessageDefinitionField],
+) -> bool:
+    """Return True if any field is not a constant."""
+    return any(field.isConstant is not True for field in fields)

--- a/mcap_ros2idl_support/rostime/__init__.py
+++ b/mcap_ros2idl_support/rostime/__init__.py
@@ -1,0 +1,251 @@
+"""ROS Time and Duration utilities."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+
+@dataclass
+class Time:
+    """Represents a ROS time with second and nanosecond fields."""
+
+    sec: int
+    nsec: int
+
+
+Duration = Time
+
+
+def is_time(obj: object | None) -> bool:
+    """Return ``True`` if *obj* looks like a :class:`Time`."""
+
+    if isinstance(obj, Time):
+        return True
+    if isinstance(obj, dict):
+        return set(obj.keys()) == {"sec", "nsec"}
+    return False
+
+
+def to_string(stamp: Time, allow_negative: bool = False) -> str:
+    if not allow_negative and (stamp.sec < 0 or stamp.nsec < 0):
+        raise ValueError(
+            f"Invalid negative time {{ sec: {stamp.sec}, nsec: {stamp.nsec} }}"
+        )
+    return f"{int(stamp.sec)}.{int(stamp.nsec):09d}"
+
+
+def _parse_nanoseconds(digits: str) -> int:
+    digits_short = 9 - len(digits)
+    return round(int(digits, 10) * 10**digits_short)
+
+
+def from_string(text: str) -> Optional[Time]:
+    if re.fullmatch(r"\d+\.?", text):
+        sec = int(text.rstrip("."))
+        return Time(sec=sec, nsec=0)
+    if not re.fullmatch(r"\d+\.\d+", text):
+        return None
+    whole, frac = text.split(".", 1)
+    sec = int(whole)
+    nsec = _parse_nanoseconds(frac)
+    return fix_time(Time(sec=sec, nsec=nsec))
+
+
+def to_rfc3339_string(stamp: Time) -> str:
+    if stamp.sec < 0 or stamp.nsec < 0:
+        raise ValueError(
+            f"Invalid negative time {{ sec: {stamp.sec}, nsec: {stamp.nsec} }}"
+        )
+    if stamp.nsec >= 1_000_000_000:
+        raise ValueError(f"Invalid nanosecond value {stamp.nsec}")
+    date = datetime.fromtimestamp(stamp.sec, tz=timezone.utc)
+    return date.strftime("%Y-%m-%dT%H:%M:%S") + f".{stamp.nsec:09d}Z"
+
+
+_RFC3339_RE = re.compile(
+    r"^(\d{4,})-(\d\d)-(\d\d)[Tt](\d\d):(\d\d):(\d\d)"
+    r"(?:\.(\d+))?(?:[Zz]|([+-])(\d\d):(\d\d))$"
+)
+
+
+def from_rfc3339_string(text: str) -> Optional[Time]:
+    m = _RFC3339_RE.fullmatch(text)
+    if not m:
+        return None
+    year, month, day, hour, minute, second, frac, sign, off_h, off_m = m.groups()
+    dt = datetime(
+        int(year),
+        int(month),
+        int(day),
+        int(hour),
+        int(minute),
+        int(second),
+        tzinfo=timezone.utc,
+    )
+    if sign:
+        offset = timedelta(hours=int(off_h), minutes=int(off_m))
+        if sign == "+":
+            dt -= offset
+        else:
+            dt += offset
+    sec = int(dt.timestamp())
+    nsec = _parse_nanoseconds(frac) if frac else 0
+    return fix_time(Time(sec=sec, nsec=nsec))
+
+
+def to_date(stamp: Time) -> datetime:
+    return datetime.fromtimestamp(stamp.sec + stamp.nsec / 1e9, tz=timezone.utc)
+
+
+def from_date(date: datetime) -> Time:
+    millis = int(date.timestamp() * 1000)
+    sec = millis // 1000
+    nsec = (millis % 1000) * 1_000_000
+    return Time(sec=sec, nsec=nsec)
+
+
+def percent_of(start: Time, end: Time, target: Time) -> float:
+    total = subtract(end, start)
+    part = subtract(target, start)
+    return to_sec(part) / to_sec(total)
+
+
+def interpolate(start: Time, end: Time, fraction: float) -> Time:
+    duration = subtract(end, start)
+    return add(start, from_sec(fraction * to_sec(duration)))
+
+
+def fix_time(t: Time, allow_negative: bool = False) -> Time:
+    secs_from_nanos = t.nsec // 1_000_000_000
+    new_sec = t.sec + secs_from_nanos
+    new_nsec = t.nsec % 1_000_000_000
+    if new_nsec < 0:
+        new_nsec += 1_000_000_000
+        new_sec -= 1
+    result = Time(sec=new_sec, nsec=new_nsec)
+    if (not allow_negative and result.sec < 0) or result.nsec < 0:
+        raise ValueError(f"Cannot normalize invalid time {to_string(result, True)}")
+    return result
+
+
+def add(a: Time, b: Time) -> Time:
+    return fix_time(Time(sec=a.sec + b.sec, nsec=a.nsec + b.nsec))
+
+
+def subtract(a: Time, b: Time) -> Time:
+    return fix_time(Time(sec=a.sec - b.sec, nsec=a.nsec - b.nsec), allow_negative=True)
+
+
+def to_nanosec(t: Time) -> int:
+    return t.sec * 1_000_000_000 + t.nsec
+
+
+def to_microsec(t: Time) -> float:
+    return (t.sec * 1_000_000_000 + t.nsec) / 1000
+
+
+def to_sec(t: Time) -> float:
+    return t.sec + t.nsec * 1e-9
+
+
+def from_sec(value: float) -> Time:
+    sec = math.trunc(value)
+    nsec = round((value - sec) * 1_000_000_000)
+    sec += math.trunc(nsec / 1_000_000_000)
+    nsec %= 1_000_000_000
+    return Time(sec=sec, nsec=nsec)
+
+
+def from_nanosec(nsec: int) -> Time:
+    return Time(sec=nsec // 1_000_000_000, nsec=nsec % 1_000_000_000)
+
+
+def to_millis(t: Time, round_up: bool = True) -> int:
+    seconds_millis = t.sec * 1000
+    nsec_millis = t.nsec / 1_000_000
+    if round_up:
+        return seconds_millis + math.ceil(nsec_millis)
+    return seconds_millis + math.floor(nsec_millis)
+
+
+def from_millis(value: int | float) -> Time:
+    sec = math.trunc(value / 1000)
+    nsec = round((value - sec * 1000) * 1_000_000)
+    sec += math.trunc(nsec / 1_000_000_000)
+    nsec %= 1_000_000_000
+    return Time(sec=sec, nsec=nsec)
+
+
+def from_micros(value: int | float) -> Time:
+    sec = math.trunc(value / 1_000_000)
+    nsec = round((value - sec * 1_000_000) * 1000)
+    sec += math.trunc(nsec / 1_000_000_000)
+    nsec %= 1_000_000_000
+    return Time(sec=sec, nsec=nsec)
+
+
+def clamp_time(time: Time, start: Time, end: Time) -> Time:
+    if compare(start, time) > 0:
+        return Time(sec=start.sec, nsec=start.nsec)
+    if compare(end, time) < 0:
+        return Time(sec=end.sec, nsec=end.nsec)
+    return Time(sec=time.sec, nsec=time.nsec)
+
+
+def is_time_in_range_inclusive(time: Time, start: Time, end: Time) -> bool:
+    if compare(start, time) > 0 or compare(end, time) < 0:
+        return False
+    return True
+
+
+def compare(left: Time, right: Time) -> int:
+    sec_diff = left.sec - right.sec
+    return sec_diff if sec_diff != 0 else left.nsec - right.nsec
+
+
+def is_less_than(left: Time, right: Time) -> bool:
+    return compare(left, right) < 0
+
+
+def is_greater_than(left: Time, right: Time) -> bool:
+    return compare(left, right) > 0
+
+
+def are_equal(left: Time, right: Time) -> bool:
+    return left.sec == right.sec and left.nsec == right.nsec
+
+
+__all__ = [
+    "Time",
+    "Duration",
+    "is_time",
+    "to_string",
+    "from_string",
+    "to_rfc3339_string",
+    "from_rfc3339_string",
+    "to_date",
+    "from_date",
+    "percent_of",
+    "interpolate",
+    "fix_time",
+    "add",
+    "subtract",
+    "to_nanosec",
+    "to_microsec",
+    "to_sec",
+    "from_sec",
+    "from_nanosec",
+    "to_millis",
+    "from_millis",
+    "from_micros",
+    "clamp_time",
+    "is_time_in_range_inclusive",
+    "compare",
+    "is_less_than",
+    "is_greater_than",
+    "are_equal",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ license = { file = "LICENSE" }
 authors = [{ name = "dskkato" }]
 dependencies = [
     "mcap>=1.3.0",
-    "rosmsg @ git+https://github.com/dskkato/ros-typescript.git@main"
+    "lark",
+    "typing-extensions",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/tests/cdr/test_reader.py
+++ b/tests/cdr/test_reader.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+import pytest
+
+from mcap_ros2idl_support.cdr.encapsulation_kind import EncapsulationKind
+from mcap_ros2idl_support.cdr.reader import CdrReader
+from mcap_ros2idl_support.cdr.writer import CdrWriter
+
+TF2_MSG_TFMESSAGE = (
+    "0001000001000000cce0d158f08cf9060a000000626173655f6c696e6b0000000600000072616461"
+    "72000000ae47e17a14ae0e4000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000000000000000000f03f"
+)
+
+
+def test_parses_example_tf2_message() -> None:
+    data = bytes.fromhex(TF2_MSG_TFMESSAGE)
+    reader = CdrReader(data)
+    assert reader.decoded_bytes == 4
+
+    # geometry_msgs/TransformStamped[] transforms
+    assert reader.sequence_length() == 1
+    # std_msgs/Header header
+    # time stamp
+    assert reader.uint32() == 1490149580  # uint32 sec
+    assert reader.uint32() == 117017840  # uint32 nsec
+    assert reader.string() == "base_link"  # string frame_id
+    assert reader.string() == "radar"  # string child_frame_id
+    # geometry_msgs/Transform transform
+    # geometry_msgs/Vector3 translation
+    assert reader.float64() == pytest.approx(3.835)  # float64 x
+    assert reader.float64() == pytest.approx(0)  # float64 y
+    assert reader.float64() == pytest.approx(0)  # float64 z
+    # geometry_msgs/Quaternion rotation
+    assert reader.float64() == pytest.approx(0)  # float64 x
+    assert reader.float64() == pytest.approx(0)  # float64 y
+    assert reader.float64() == pytest.approx(0)  # float64 z
+    assert reader.float64() == pytest.approx(1)  # float64 w
+
+    assert reader.offset == len(data)
+    assert reader.kind == EncapsulationKind.CDR_LE
+    assert reader.decoded_bytes == len(data)
+    assert reader.byte_length == len(data)
+
+
+def test_reads_big_endian_values() -> None:
+    data = bytes.fromhex("000100001234000056789abcdef0000000000000")
+    reader = CdrReader(data)
+    assert reader.uint16_be() == 0x1234
+    assert reader.uint32_be() == 0x56789ABC
+    assert reader.uint64_be() == 0xDEF0000000000000
+
+
+def test_seeks_absolute_and_relative_positions() -> None:
+    data = bytes.fromhex(TF2_MSG_TFMESSAGE)
+    reader = CdrReader(data)
+
+    reader.seek_to(4 + 4 + 4 + 4 + 4 + 10 + 4 + 6)
+    assert reader.float64() == pytest.approx(3.835)
+
+    reader.seek_to(4 + 4 + 4 + 4 + 4 + 10 + 4 + 3)
+    assert reader.float64() == pytest.approx(3.835)
+
+    reader.seek(-8)
+    assert reader.float64() == pytest.approx(3.835)
+    assert reader.float64() == pytest.approx(0)
+
+
+@pytest.mark.parametrize(
+    "getter,setter,expected",
+    [
+        ("int8_array", "int8", [-128, 127, 3]),
+        ("uint8_array", "uint8", [0, 255, 3]),
+        ("int16_array", "int16", [-32768, 32767, -3]),
+        ("uint16_array", "uint16", [0, 65535, 3]),
+        ("int32_array", "int32", [-2147483648, 2147483647, 3]),
+        ("uint32_array", "uint32", [0, 4294967295, 3]),
+    ],
+)
+def test_reads_int_arrays(getter: str, setter: str, expected: list[int]) -> None:
+    writer = CdrWriter()
+    _write_array(writer, setter, expected)
+
+    reader = CdrReader(writer.data)
+    array = getattr(reader, getter)()
+    assert list(array) == expected
+
+
+@pytest.mark.parametrize(
+    "getter,setter,expected,num_digits",
+    [
+        ("float32_array", "float32", [-3.835, 0, math.pi], 6),
+        ("float64_array", "float64", [-3.835, 0, math.pi], 15),
+        (
+            "float64_array",
+            "float64",
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, -0.123456789121212121212],
+            15,
+        ),
+    ],
+)
+def test_reads_float_arrays(
+    getter: str, setter: str, expected: list[float], num_digits: int
+) -> None:
+    writer = CdrWriter()
+    _write_array(writer, setter, expected)
+
+    reader = CdrReader(writer.data)
+    array = getattr(reader, getter)()
+    _assert_close_list(array, expected, num_digits)
+
+
+@pytest.mark.parametrize(
+    "getter,setter,expected",
+    [
+        (
+            "int64_array",
+            "int64",
+            [-9223372036854775808, 9223372036854775807, 3],
+        ),
+        (
+            "uint64_array",
+            "uint64",
+            [0, 18446744073709551615, 3],
+        ),
+        ("uint64_array", "uint64", list(range(1, 13))),
+    ],
+)
+def test_reads_bigint_arrays(getter: str, setter: str, expected: list[int]) -> None:
+    writer = CdrWriter()
+    _write_array(writer, setter, expected)
+
+    reader = CdrReader(writer.data)
+    array = getattr(reader, getter)()
+    assert list(array) == expected
+
+
+def test_reads_multiple_arrays() -> None:
+    writer = CdrWriter()
+    writer.float32Array([5.5, 6.5], True)
+    writer.float32Array([7.5, 8.5], True)
+
+    reader = CdrReader(writer.data)
+    assert _approx_list(reader.float32_array(), [5.5, 6.5], 6)
+    assert _approx_list(reader.float32_array(), [7.5, 8.5], 6)
+    assert reader.offset == len(writer.data)
+
+
+def test_reads_string_array() -> None:
+    writer = CdrWriter()
+    writer.sequenceLength(3)
+    writer.string("abc")
+    writer.string("")
+    writer.string("test string")
+
+    reader = CdrReader(writer.data)
+    assert reader.string_array() == ["abc", "", "test string"]
+    assert reader.offset == len(writer.data)
+
+
+@pytest.mark.parametrize(
+    "writer_key,reader_key",
+    [
+        ("int8Array", "int8_array"),
+        ("uint8Array", "uint8_array"),
+        ("int16Array", "int16_array"),
+        ("uint16Array", "uint16_array"),
+        ("int32Array", "int32_array"),
+        ("uint32Array", "uint32_array"),
+        ("int64Array", "int64_array"),
+        ("uint64Array", "uint64_array"),
+        ("float32Array", "float32_array"),
+        ("float64Array", "float64_array"),
+    ],
+)
+def test_handles_alignment_for_empty_arrays(writer_key: str, reader_key: str) -> None:
+    writer = CdrWriter()
+    getattr(writer, writer_key)([], True)
+    assert len(writer.data) == 8
+
+    reader = CdrReader(writer.data)
+    assert list(getattr(reader, reader_key)()) == []
+    assert reader.offset == len(writer.data)
+
+
+@pytest.mark.parametrize(
+    "getter,setter,values,digits",
+    [
+        ("int8_array", "int8", [-1, 2, 3], None),
+        ("uint8_array", "uint8", [1, 2, 3], None),
+        ("int16_array", "int16", [-1, 2, 3], None),
+        ("uint16_array", "uint16", [1, 2, 3], None),
+        ("int32_array", "int32", [-1, 2, 3], None),
+        ("uint32_array", "uint32", [1, 2, 3], None),
+        ("int64_array", "int64", [-1, 2, 3], None),
+        ("uint64_array", "uint64", [1, 2, 3], None),
+        ("float32_array", "float32", [1.5, 2.5, 3.5], 6),
+        ("float64_array", "float64", [1.5, 2.5, 3.5], 15),
+    ],
+)
+def test_array_returns_memoryview_zero_copy(
+    getter: str, setter: str, values: list[int | float], digits: int | None
+) -> None:
+    writer = CdrWriter()
+    _write_array(writer, setter, values)
+
+    reader = CdrReader(writer.data)
+    mv = getattr(reader, getter)()
+    assert isinstance(mv, memoryview)
+    assert mv.obj is reader._view.obj
+    if digits is None:
+        assert list(mv) == values
+    else:
+        _assert_close_list(mv, values, digits)
+
+
+def test_array_falls_back_on_endian_mismatch() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.CDR_BE)
+    _write_array(writer, "uint32", [1, 2, 3])
+
+    reader = CdrReader(writer.data)
+    arr = reader.uint32_array()
+    assert isinstance(arr, list)
+    assert arr == [1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    "must_understand,pid,object_size",
+    [
+        (True, 100, 1),
+        (False, 200, 2),
+        (False, 1028, 4),
+        (False, 65, 8),
+        (True, 63, 9),
+        (False, 127, 0xFFFF),
+        (False, 127, 0x1FFFF),
+        (True, 700000, 0xFFFF),
+        (False, 700000, 0x1FFFF),
+    ],
+)
+def test_round_trip_xcdr1_em_header(
+    must_understand: bool, pid: int, object_size: int
+) -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR_BE)
+    writer.emHeader(must_understand, pid, object_size)
+
+    reader = CdrReader(writer.data)
+    header = reader.em_header()
+    assert header.id == pid
+    assert header.object_size == object_size
+    assert header.must_understand is must_understand
+
+
+def test_converts_extended_pid() -> None:
+    buffer = bytes.fromhex("00030000017f0800640000004000000000")
+    reader = CdrReader(buffer)
+    header = reader.em_header()
+    assert header.id == 100
+    assert header.must_understand is True
+    assert header.object_size == 64
+
+
+def test_read_string_with_preread_length() -> None:
+    writer = CdrWriter()
+    writer.string("test")
+
+    reader = CdrReader(writer.data)
+    length = reader.sequence_length()
+    assert reader.string(length) == "test"
+
+
+def test_em_header_reports_sentinel_read() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR_LE)
+    writer.sentinelHeader()
+
+    reader = CdrReader(writer.data)
+    em_header = reader.em_header()
+    assert em_header.read_sentinel_header is True
+
+
+def test_sentinel_header_errors_on_non_sentinel() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR_LE)
+    writer.emHeader(False, 100, 4)
+
+    reader = CdrReader(writer.data)
+    with pytest.raises(ValueError):
+        reader.sentinel_header()
+
+
+@pytest.mark.parametrize("object_size", [1, 2, 4, 8, 0x7FFFFFFF])
+def test_round_trip_dheader(object_size: int) -> None:
+    writer = CdrWriter(kind=EncapsulationKind.DELIMITED_CDR2_LE)
+    writer.dHeader(object_size)
+
+    reader = CdrReader(writer.data)
+    assert reader.d_header() == object_size
+
+
+@pytest.mark.parametrize(
+    "must_understand,pid,object_size",
+    [
+        (True, 100, 1),
+        (False, 200, 2),
+        (False, 1028, 4),
+        (False, 65, 8),
+        (True, 63, 9),
+        (False, 127, 0xFFFFFFFF),
+    ],
+)
+def test_round_trip_emheader_without_length_code(
+    must_understand: bool, pid: int, object_size: int
+) -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR2_LE)
+    writer.emHeader(must_understand, pid, object_size)
+
+    reader = CdrReader(writer.data)
+    header = reader.em_header()
+    assert header.id == pid
+    assert header.object_size == object_size
+    assert header.must_understand is must_understand
+    assert header.length_code is not None
+
+
+@pytest.mark.parametrize(
+    "must_understand,pid,object_size,length_code",
+    [
+        (True, 100, 1, 0),
+        (False, 200, 2, 1),
+        (False, 1028, 4, 2),
+        (False, 65, 8, 3),
+        (True, 63, 9, 4),
+        (False, 127, 0xFFFFFFFF, 5),
+        (False, 65, 12, 6),
+        (False, 65, 32, 7),
+    ],
+)
+def test_round_trip_emheader_with_length_code(
+    must_understand: bool, pid: int, object_size: int, length_code: int
+) -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR2_LE)
+    writer.emHeader(must_understand, pid, object_size, length_code)
+
+    reader = CdrReader(writer.data)
+    header = reader.em_header()
+    assert header.id == pid
+    assert header.object_size == object_size
+    assert header.must_understand is must_understand
+    assert header.length_code == length_code
+
+
+def test_clone_creates_independent_reader() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.CDR2_LE)
+    writer.int32(42)
+    writer.float64(2.67)
+
+    reader = CdrReader(writer.data)
+    assert reader.int32() == 42
+
+    clone = reader.clone()
+    assert clone.offset == reader.offset
+    assert clone.byte_length == reader.byte_length
+
+    assert reader.float64() == pytest.approx(2.67)
+    assert reader.offset == 4 + 4 + 8
+    assert clone.offset == 4 + 4
+    assert clone.float64() == pytest.approx(2.67)
+
+
+def test_limit_restricts_readable_range() -> None:
+    writer = CdrWriter()
+    writer.int32(1)
+    writer.int32(2)
+    writer.int32(3)
+
+    reader = CdrReader(writer.data)
+    assert reader.int32() == 1
+    reader.limit(4)
+    assert reader.int32() == 2
+    assert reader.is_at_end() is True
+    with pytest.raises(Exception):
+        reader.int32()
+
+
+def test_limit_throws_if_length_beyond_end() -> None:
+    writer = CdrWriter()
+    writer.int32(1)
+    reader = CdrReader(writer.data)
+    with pytest.raises(ValueError):
+        reader.limit(1000)
+
+
+def test_limit_cannot_be_relaxed() -> None:
+    writer = CdrWriter()
+    writer.int32(1)
+    reader = CdrReader(writer.data)
+    reader.limit(2)
+    reader.limit(1)
+    with pytest.raises(ValueError):
+        reader.limit(2)
+
+
+def test_is_at_end() -> None:
+    writer = CdrWriter()
+    writer.int32(1)
+    reader = CdrReader(writer.data)
+    assert reader.is_at_end() is False
+    reader.int32()
+    assert reader.is_at_end() is True
+
+
+def _write_array(writer: CdrWriter, setter: str, values: list[int | float]) -> None:
+    writer.sequenceLength(len(values))
+    for value in values:
+        getattr(writer, setter)(value)
+
+
+def _assert_close_list(
+    actual: Sequence[float], expected: Sequence[float], digits: int
+) -> None:
+    assert len(actual) == len(expected)
+    for a, e in zip(actual, expected):
+        assert a == pytest.approx(e, rel=0, abs=10**-digits)
+
+
+def _approx_list(
+    actual: Sequence[float], expected: Sequence[float], digits: int
+) -> bool:
+    _assert_close_list(actual, expected, digits)
+    return True

--- a/tests/cdr/test_size_calculator.py
+++ b/tests/cdr/test_size_calculator.py
@@ -1,0 +1,107 @@
+"""Tests for :mod:`cdr.size_calculator`."""
+
+from __future__ import annotations
+
+from mcap_ros2idl_support.cdr.size_calculator import CdrSizeCalculator
+
+
+def test_calculates_example_message() -> None:
+    """Ensure example tf2_msgs/TFMessage size matches reference."""
+    calc = CdrSizeCalculator()
+
+    # geometry_msgs/TransformStamped[] transforms
+    calc.sequence_length()
+    # std_msgs/Header header
+    # time stamp
+    calc.uint32()  # uint32 sec
+    calc.uint32()  # uint32 nsec
+    calc.string(len("base_link"))  # string frame_id
+    calc.string(len("radar"))  # string child_frame_id
+    # geometry_msgs/Transform transform
+    # geometry_msgs/Vector3 translation
+    calc.float64()  # float64 x
+    calc.float64()  # float64 y
+    calc.float64()  # float64 z
+    # geometry_msgs/Quaternion rotation
+    calc.float64()  # float64 x
+    calc.float64()  # float64 y
+    calc.float64()  # float64 z
+    calc.float64()  # float64 w
+
+    assert calc.size == 100
+
+
+def test_string_accounts_for_length_and_terminator() -> None:
+    calc = CdrSizeCalculator()
+    assert calc.size == 4
+    assert calc.string(0) == 9  # 4 bytes length + 1 byte terminator
+    assert calc.size == 9
+
+
+def test_sequence_length_alignment() -> None:
+    calc = CdrSizeCalculator()
+    calc.int8()  # misalign the offset
+    assert calc.sequence_length() == 12  # 3 padding bytes + 4 length bytes
+
+
+def test_all_data_types_without_padding() -> None:
+    """Offsets match Node.js implementation when no padding is required."""
+    calc = CdrSizeCalculator()
+    offset = 4  # initial encapsulation header
+    assert calc.size == offset
+
+    offset += 8
+    assert calc.int64() == offset
+
+    offset += 8
+    assert calc.uint64() == offset
+
+    offset += 8
+    assert calc.float64() == offset
+
+    offset += 4
+    assert calc.int32() == offset
+
+    offset += 4
+    assert calc.uint32() == offset
+
+    offset += 4
+    assert calc.float32() == offset
+
+    offset += 4
+    assert calc.sequence_length() == offset
+
+    offset += 2
+    assert calc.int16() == offset
+
+    offset += 2
+    assert calc.uint16() == offset
+
+    offset += 1
+    assert calc.int8() == offset
+
+    offset += 1
+    assert calc.uint8() == offset
+
+    offset += 2
+    assert calc.uint16() == offset
+
+    offset += 4 + 3 + 1  # length prefix, string data, null terminator
+    assert calc.string(len("abc")) == offset
+
+
+def test_all_data_types_with_padding() -> None:
+    """Offsets match Node.js implementation when padding is required."""
+    calc = CdrSizeCalculator()
+
+    assert calc.size == 4
+    assert calc.int8() == 5
+    assert calc.int64() == 20
+    assert calc.uint16() == 22
+    assert calc.uint32() == 28
+    assert calc.string(0) == 33
+    assert calc.int16() == 36
+    assert calc.uint8() == 37
+    assert calc.float32() == 44
+    assert calc.uint8() == 45
+    assert calc.float64() == 60

--- a/tests/cdr/test_writer.py
+++ b/tests/cdr/test_writer.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from array import array
+
+import pytest
+
+from mcap_ros2idl_support.cdr.encapsulation_kind import EncapsulationKind
+from mcap_ros2idl_support.cdr.reader import CdrReader
+from mcap_ros2idl_support.cdr.writer import CdrWriter
+
+CDR2_KINDS = {
+    EncapsulationKind.CDR2_BE,
+    EncapsulationKind.CDR2_LE,
+    EncapsulationKind.PL_CDR2_BE,
+    EncapsulationKind.PL_CDR2_LE,
+    EncapsulationKind.DELIMITED_CDR2_BE,
+    EncapsulationKind.DELIMITED_CDR2_LE,
+    EncapsulationKind.RTPS_CDR2_BE,
+    EncapsulationKind.RTPS_CDR2_LE,
+    EncapsulationKind.RTPS_PL_CDR2_BE,
+    EncapsulationKind.RTPS_PL_CDR2_LE,
+    EncapsulationKind.RTPS_DELIMITED_CDR2_BE,
+    EncapsulationKind.RTPS_DELIMITED_CDR2_LE,
+}
+
+TF2_MSG_TFMESSAGE = (
+    "0001000001000000cce0d158f08cf9060a000000626173655f6c696e6b0000000600000072616461"
+    "72000000ae47e17a14ae0e4000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000000000000000000f03f"
+)
+
+
+def write_example_message(writer: CdrWriter) -> None:
+    # geometry_msgs/TransformStamped[] transforms
+    writer.sequenceLength(1)
+    # std_msgs/Header header
+    # time stamp
+    writer.uint32(1490149580)  # uint32 sec
+    writer.uint32(117017840)  # uint32 nsec
+    writer.string("base_link")  # string frame_id
+    writer.string("radar")  # string child_frame_id
+    # geometry_msgs/Transform transform
+    # geometry_msgs/Vector3 translation
+    writer.float64(3.835)  # float64 x
+    writer.float64(0)  # float64 y
+    writer.float64(0)  # float64 z
+    # geometry_msgs/Quaternion rotation
+    writer.float64(0)  # float64 x
+    writer.float64(0)  # float64 y
+    writer.float64(0)  # float64 z
+    writer.float64(1)  # float64 w
+
+
+@pytest.mark.parametrize("kwargs", [{"size": 100}, {"buffer": bytearray(100)}])
+@pytest.mark.parametrize("kind", [EncapsulationKind.CDR_LE, EncapsulationKind.CDR2_LE])
+def test_serializes_example_message_with_preallocation(
+    kind: EncapsulationKind,
+    kwargs: dict,
+) -> None:
+    writer = CdrWriter(kind=kind, **kwargs)
+    write_example_message(writer)
+    assert writer.size == 100
+    expected = bytearray.fromhex(TF2_MSG_TFMESSAGE)
+    expected[1] = kind.value
+    assert writer.data == bytes(expected)
+
+
+def test_serializes_example_message_without_preallocation() -> None:
+    writer = CdrWriter()
+    write_example_message(writer)
+    assert writer.size == 100
+    assert writer.data.hex() == TF2_MSG_TFMESSAGE
+
+
+@pytest.mark.parametrize("kind", list(EncapsulationKind))
+def test_round_trips_all_primitive_types(kind: EncapsulationKind) -> None:
+    writer = CdrWriter(kind=kind)
+    writer.int8(-1)
+    writer.uint8(2)
+    writer.int16(-300)
+    writer.uint16(400)
+    writer.int32(-500_000)
+    writer.uint32(600_000)
+    writer.int64(-7_000_000_001)
+    writer.uint64(8_000_000_003)
+    writer.uint16BE(0x1234)
+    writer.uint32BE(0x12345678)
+    writer.uint64BE(0x123456789ABCDEF0)
+    writer.float32(-9.14)
+    writer.float64(1.7976931348623158e100)
+    writer.string("abc")
+    writer.sequenceLength(42)
+    data = writer.data
+    assert len(data) == (76 if kind in CDR2_KINDS else 80)
+
+    reader = CdrReader(data)
+    assert reader.int8() == -1
+    assert reader.uint8() == 2
+    assert reader.int16() == -300
+    assert reader.uint16() == 400
+    assert reader.int32() == -500_000
+    assert reader.uint32() == 600_000
+    assert reader.int64() == -7_000_000_001
+    assert reader.uint64() == 8_000_000_003
+    assert reader.uint16_be() == 0x1234
+    assert reader.uint32_be() == 0x12345678
+    assert reader.uint64_be() == 0x123456789ABCDEF0
+    assert reader.float32() == pytest.approx(-9.14)
+    assert reader.float64() == pytest.approx(1.7976931348623158e100)
+    assert reader.string() == "abc"
+    assert reader.sequence_length() == 42
+
+
+@pytest.mark.parametrize("kind", list(EncapsulationKind))
+def test_round_trips_all_array_types(kind: EncapsulationKind) -> None:
+    writer = CdrWriter(kind=kind)
+    writer.int8Array([-128, 127, 3], True)
+    writer.uint8Array([0, 255, 3], True)
+    writer.int16Array([-32768, 32767, -3], True)
+    writer.uint16Array([0, 65535, 3], True)
+    writer.int32Array([-2147483648, 2147483647, 3], True)
+    writer.uint32Array([0, 4294967295, 3], True)
+    writer.int64Array([-9223372036854775808, 9223372036854775807, 3], True)
+    writer.uint64Array([0, 18446744073709551615, 3], True)
+
+    reader = CdrReader(writer.data)
+    assert list(reader.int8_array()) == [-128, 127, 3]
+    assert list(reader.uint8_array()) == [0, 255, 3]
+    assert list(reader.int16_array()) == [-32768, 32767, -3]
+    assert list(reader.uint16_array()) == [0, 65535, 3]
+    assert list(reader.int32_array()) == [-2147483648, 2147483647, 3]
+    assert list(reader.uint32_array()) == [0, 4294967295, 3]
+    assert list(reader.int64_array()) == [-9223372036854775808, 9223372036854775807, 3]
+    assert list(reader.uint64_array()) == [0, 18446744073709551615, 3]
+
+
+@pytest.mark.parametrize("kind", [EncapsulationKind.CDR_LE, EncapsulationKind.CDR_BE])
+@pytest.mark.parametrize(
+    "method, values, typecode",
+    [
+        ("int16Array", [-32768, 0, 32767], "h"),
+        ("uint16Array", [0, 1, 65535], "H"),
+        ("int32Array", [-2147483648, 0, 2147483647], "i"),
+        ("uint32Array", [0, 1, 0xFFFFFFFF], "I"),
+        ("int64Array", [-9223372036854775808, 0, 9223372036854775807], "q"),
+        ("uint64Array", [0, 1, 0xFFFFFFFFFFFFFFFF], "Q"),
+        ("float32Array", [0.0, 1.5, -2.25], "f"),
+        ("float64Array", [0.0, 1.5, -2.25], "d"),
+    ],
+)
+@pytest.mark.parametrize("container", ["array", "memoryview", "list"])
+def test_array_bulk_and_fallback_paths(
+    kind: EncapsulationKind,
+    method: str,
+    values: list,
+    typecode: str,
+    container: str,
+) -> None:
+    writer = CdrWriter(kind=kind)
+    if container == "array":
+        data = array(typecode, values)
+    elif container == "memoryview":
+        data = memoryview(array(typecode, values))
+    else:
+        data = list(values)
+    getattr(writer, method)(data, True)
+    reader = CdrReader(writer.data)
+    read_method = method.replace("Array", "_array")
+    result = getattr(reader, read_method)()
+    result = list(result)
+    assert result == values
+
+
+def test_writes_parameter_list_and_sentinel_header() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR_LE)
+    writer.uint8(0x42)
+    writer.sentinelHeader()
+    assert writer.data.hex() == "0003000042000000023f0000"
+
+
+def test_aligns_cdr1() -> None:
+    writer = CdrWriter()
+    writer.align(0)
+    assert writer.data.hex() == "00010000"
+    writer.align(8)
+    assert writer.data.hex() == "00010000"
+    writer.uint8(1)
+    writer.align(8)
+    writer.uint32(2)
+    writer.align(4)
+    assert writer.data.hex() == "00010000010000000000000002000000"
+
+
+def test_aligns_cdr2() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.RTPS_PL_CDR2_LE)
+    writer.align(0)
+    assert writer.data.hex() == "000b0000"
+    writer.align(4)
+    assert writer.data.hex() == "000b0000"
+    writer.uint8(1)
+    writer.align(4)
+    writer.uint32(2)
+    writer.align(4)
+    assert writer.data.hex() == "000b00000100000002000000"
+
+
+def test_aligns_8byte_values_in_pl_cdr_without_emheader() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR_LE)
+    writer.uint32(1)
+    writer.uint64(0x0F)
+    assert writer.data.hex() == "0003000001000000000000000f00000000000000"
+
+
+def test_emheader_resets_origin_for_alignment() -> None:
+    writer = CdrWriter(kind=EncapsulationKind.PL_CDR_LE)
+    writer.emHeader(True, 5, 8)
+    writer.uint64(0x0F)
+    assert writer.data.hex() == "00030000054008000f00000000000000"

--- a/tests/omgidl/test_message_definition.py
+++ b/tests/omgidl/test_message_definition.py
@@ -1,0 +1,23 @@
+from mcap_ros2idl_support.message_definition import (
+    MessageDefinition,
+    MessageDefinitionField,
+    is_msg_def_equal,
+)
+
+
+def test_is_msg_def_equal() -> None:
+    a = MessageDefinition(
+        name="Foo",
+        definitions=[MessageDefinitionField(type="string", name="data")],
+    )
+    b = MessageDefinition(
+        name="Foo",
+        definitions=[MessageDefinitionField(type="string", name="data")],
+    )
+    c = MessageDefinition(
+        name="Bar",
+        definitions=[MessageDefinitionField(type="string", name="data")],
+    )
+
+    assert is_msg_def_equal(a, b)
+    assert not is_msg_def_equal(a, c)

--- a/tests/python_ros/test_MessageReader.py
+++ b/tests/python_ros/test_MessageReader.py
@@ -1,0 +1,739 @@
+# flake8: noqa
+import struct
+
+import pytest
+
+from mcap_ros2idl_support.cdr import CdrWriter
+from mcap_ros2idl_support.ros2idl_parser import parse_ros2idl
+from mcap_ros2idl_support.rosmsg2_serialization import (
+    MessageReader,
+    MessageReaderOptions,
+)
+from mcap_ros2idl_support.rosmsg.parse import parse
+
+
+def _serialize_string(string: str) -> bytes:
+    data = string.encode("utf8")
+    return struct.pack("<I", len(data) + 1) + data + b"\x00"
+
+
+@pytest.mark.parametrize(
+    "primitive,fmt,min_val,max_val",
+    [
+        ("int8", "<b", -128, 127),
+        ("uint8", "<B", 0, 255),
+        ("int16", "<h", -32768, 32767),
+        ("uint16", "<H", 0, 65535),
+        ("int32", "<i", -2147483648, 2147483647),
+        ("uint32", "<I", 0, 4294967295),
+        ("int64", "<q", -9223372036854775808, 9223372036854775807),
+        ("uint64", "<Q", 0, 18446744073709551615),
+    ],
+)
+def test_primitive_bounds(primitive: str, fmt: str, min_val: int, max_val: int) -> None:
+    msg_def = f"{primitive} sample"
+    defs = parse(msg_def, ros2=True)
+    reader = MessageReader(defs)
+    for val in (min_val, max_val):
+        buffer = b"\x00\x01\x00\x00" + struct.pack(fmt, val)
+        assert reader.read_message(buffer) == {"sample": val}
+
+
+@pytest.mark.parametrize(
+    "primitive,fmt,val",
+    [
+        ("float32", "<f", 5.5),
+        ("float64", "<d", 0.123456789121212121212),
+    ],
+)
+def test_float_samples(primitive: str, fmt: str, val: float) -> None:
+    msg_def = f"{primitive} sample"
+    defs = parse(msg_def, ros2=True)
+    reader = MessageReader(defs)
+    buffer = b"\x00\x01\x00\x00" + struct.pack(fmt, val)
+    assert reader.read_message(buffer) == {"sample": val}
+
+
+@pytest.mark.parametrize(
+    "msg_def,arr,expected",
+    [
+        (
+            "int32[] arr",
+            struct.pack("<I", 2) + struct.pack("<2i", 3, 7),
+            {"arr": [3, 7]},
+        ),
+        (
+            "uint8 blank\nint32[] arr",
+            b"\x00" + b"\x00\x00\x00" + struct.pack("<I", 2) + struct.pack("<2i", 3, 7),
+            {"blank": 0, "arr": [3, 7]},
+        ),
+        (
+            "float32[2] arr",
+            struct.pack("<2f", 5.5, 6.5),
+            {"arr": [5.5, 6.5]},
+        ),
+        (
+            "uint8 blank\nfloat32[2] arr",
+            b"\x00" + b"\x00\x00\x00" + struct.pack("<2f", 5.5, 6.5),
+            {"blank": 0, "arr": [5.5, 6.5]},
+        ),
+        (
+            "float32[] arr",
+            struct.pack("<I", 2) + struct.pack("<2f", 5.5, 6.5),
+            {"arr": [5.5, 6.5]},
+        ),
+        (
+            "uint8 blank\nfloat32[] arr",
+            b"\x00"
+            + b"\x00\x00\x00"
+            + struct.pack("<I", 2)
+            + struct.pack("<2f", 5.5, 6.5),
+            {"blank": 0, "arr": [5.5, 6.5]},
+        ),
+        (
+            "float32[] first\nfloat32[] second",
+            struct.pack("<I", 2)
+            + struct.pack("<2f", 5.5, 6.5)
+            + struct.pack("<I", 2)
+            + struct.pack("<2f", 5.5, 6.5),
+            {
+                "first": [5.5, 6.5],
+                "second": [5.5, 6.5],
+            },
+        ),
+        (
+            "string sample",
+            _serialize_string(""),
+            {"sample": ""},
+        ),
+        (
+            "string sample",
+            _serialize_string("some string"),
+            {"sample": "some string"},
+        ),
+        (
+            "int8[4] first",
+            bytes([0x00, 0xFF, 0x80, 0x7F]),
+            {"first": [0, -1, -128, 127]},
+        ),
+        (
+            "int8[] first",
+            struct.pack("<I", 4) + bytes([0x00, 0xFF, 0x80, 0x7F]),
+            {"first": [0, -1, -128, 127]},
+        ),
+        (
+            "uint8[4] first",
+            bytes([0x00, 0xFF, 0x80, 0x7F]),
+            {"first": [0, 255, 128, 127]},
+        ),
+        (
+            "string[2] first",
+            _serialize_string("one") + _serialize_string("longer string"),
+            {"first": ["one", "longer string"]},
+        ),
+        (
+            "string[] first",
+            struct.pack("<I", 2)
+            + _serialize_string("one")
+            + _serialize_string("longer string"),
+            {"first": ["one", "longer string"]},
+        ),
+        (
+            "int8 first\nint8 second",
+            bytes([0x80, 0x7F]),
+            {"first": -128, "second": 127},
+        ),
+        (
+            "string first\nint8 second",
+            _serialize_string("some string") + bytes([0x80]),
+            {"first": "some string", "second": -128},
+        ),
+        (
+            """CustomType custom
+================================================================================
+MSG: custom_type/CustomType
+uint8 first
+""",
+            bytes([0x02]),
+            {"custom": {"first": 0x02}},
+        ),
+        (
+            """CustomType[3] custom
+================================================================================
+MSG: custom_type/CustomType
+uint8 first
+""",
+            bytes([0x02, 0x03, 0x04]),
+            {"custom": [{"first": 0x02}, {"first": 0x03}, {"first": 0x04}]},
+        ),
+        (
+            """CustomType[] custom
+================================================================================
+MSG: custom_type/CustomType
+uint8 first
+""",
+            struct.pack("<I", 3) + bytes([0x02, 0x03, 0x04]),
+            {"custom": [{"first": 0x02}, {"first": 0x03}, {"first": 0x04}]},
+        ),
+        (
+            "int8 STATUS_ONE = 1\nint8 STATUS_TWO = 2\nint8 status",
+            bytes([0x02]),
+            {"status": 2},
+        ),
+        (
+            """CustomType[] custom
+================================================================================
+MSG: custom_type/CustomType
+MoreCustom another
+================================================================================
+MSG: custom_type/MoreCustom
+uint8 field
+""",
+            struct.pack("<I", 3) + bytes([0x02, 0x03, 0x04]),
+            {
+                "custom": [
+                    {"another": {"field": 0x02}},
+                    {"another": {"field": 0x03}},
+                    {"another": {"field": 0x04}},
+                ]
+            },
+        ),
+    ],
+)
+def test_misc_cases(msg_def: str, arr: bytes, expected: dict) -> None:
+    defs = parse(msg_def, ros2=True)
+    reader = MessageReader(defs)
+    buffer = b"\x00\x01\x00\x00" + arr
+    assert reader.read_message(buffer) == expected
+
+
+@pytest.mark.parametrize(
+    "msg_def,arr,expected,ros1_expected",
+    [
+        (
+            "time stamp",
+            struct.pack("<iI", 0, 1),
+            {"stamp": {"sec": 0, "nanosec": 1}},
+            {"stamp": {"sec": 0, "nsec": 1}},
+        ),
+        (
+            "duration stamp",
+            struct.pack("<iI", 0, 1),
+            {"stamp": {"sec": 0, "nanosec": 1}},
+            {"stamp": {"sec": 0, "nsec": 1}},
+        ),
+        (
+            "time[1] arr",
+            struct.pack("<iI", 1, 2),
+            {"arr": [{"sec": 1, "nanosec": 2}]},
+            {"arr": [{"sec": 1, "nsec": 2}]},
+        ),
+        (
+            "duration[1] arr",
+            struct.pack("<iI", 1, 2),
+            {"arr": [{"sec": 1, "nanosec": 2}]},
+            {"arr": [{"sec": 1, "nsec": 2}]},
+        ),
+        (
+            "time[] arr",
+            struct.pack("<I", 1) + struct.pack("<iI", 2, 3),
+            {"arr": [{"sec": 2, "nanosec": 3}]},
+            {"arr": [{"sec": 2, "nsec": 3}]},
+        ),
+        (
+            "duration[] arr",
+            struct.pack("<I", 1) + struct.pack("<iI", 2, 3),
+            {"arr": [{"sec": 2, "nanosec": 3}]},
+            {"arr": [{"sec": 2, "nsec": 3}]},
+        ),
+        (
+            "uint8 blank\ntime[] arr",
+            b"\x00" + b"\x00\x00\x00" + struct.pack("<I", 1) + struct.pack("<iI", 2, 3),
+            {"blank": 0, "arr": [{"sec": 2, "nanosec": 3}]},
+            {"blank": 0, "arr": [{"sec": 2, "nsec": 3}]},
+        ),
+    ],
+)
+def test_time_type_option(
+    msg_def: str, arr: bytes, expected: dict, ros1_expected: dict
+) -> None:
+    defs = parse(msg_def, ros2=True)
+    buffer = b"\x00\x01\x00\x00" + arr
+    assert MessageReader(defs).read_message(buffer) == expected
+    assert (
+        MessageReader(defs, MessageReaderOptions(timeType="sec,nsec")).read_message(
+            buffer
+        )
+        == ros1_expected
+    )
+
+
+def test_log_message() -> None:
+    hexdata = "00010000fb65865e80faae0614000000120000006d696e696d616c5f7075626c69736865720000001e0000005075626c697368696e673a202748656c6c6f2c20776f726c64212030270000004c0000002f6f70742f726f73325f77732f656c6f7175656e742f7372632f726f73322f6578616d706c65732f72636c6370702f6d696e696d616c5f7075626c69736865722f6c616d6264612e637070000b0000006f70657261746f722829007326000000"
+    buffer = bytes.fromhex(hexdata)
+    msg_def = """byte DEBUG=10
+byte INFO=20
+byte WARN=30
+byte ERROR=40
+byte FATAL=50
+##
+## Fields
+##
+builtin_interfaces/Time stamp
+uint8 level
+string name # name of the node
+string msg # message
+string file # file the message came from
+string function # function the message came from
+uint32 line # line the message came from
+"""
+    defs = parse(msg_def, ros2=True)
+    reader = MessageReader(defs)
+    read = reader.read_message(buffer)
+    assert read == {
+        "stamp": {"sec": 1585866235, "nanosec": 112130688},
+        "level": 20,
+        "name": "minimal_publisher",
+        "msg": "Publishing: 'Hello, world! 0'",
+        "file": "/opt/ros2_ws/eloquent/src/ros2/examples/rclcpp/minimal_publisher/lambda.cpp",
+        "function": "operator()",
+        "line": 38,
+    }
+
+
+def test_tf_message() -> None:
+    hexdata = "0001000001000000286fae6169ddd73108000000747572746c6531000e000000747572746c65315f616865616400000000000000000000000000f03f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f03f"
+    buffer = bytes.fromhex(hexdata)
+    msg_def = """geometry_msgs/TransformStamped[] transforms
+================================================================================
+MSG: geometry_msgs/TransformStamped
+Header header
+string child_frame_id # the frame id of the child frame
+Transform transform
+================================================================================
+MSG: std_msgs/Header
+time stamp
+string frame_id
+================================================================================
+MSG: geometry_msgs/Transform
+Vector3 translation
+Quaternion rotation
+================================================================================
+MSG: geometry_msgs/Vector3
+float64 x
+float64 y
+float64 z
+================================================================================
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w
+"""
+    defs = parse(msg_def, ros2=True)
+    reader = MessageReader(defs)
+    read = reader.read_message(buffer)
+    assert read == {
+        "transforms": [
+            {
+                "header": {
+                    "stamp": {"sec": 1638821672, "nanosec": 836230505},
+                    "frame_id": "turtle1",
+                },
+                "child_frame_id": "turtle1_ahead",
+                "transform": {
+                    "translation": {"x": 1, "y": 0, "z": 0},
+                    "rotation": {"x": 0, "y": 0, "z": 0, "w": 1},
+                },
+            }
+        ]
+    }
+
+
+def test_ros2idl_tf_message() -> None:
+    hexdata = "0001000001000000286fae6169ddd73108000000747572746c6531000e000000747572746c65315f616865616400000000000000000000000000f03f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f03f"
+    buffer = bytes.fromhex(hexdata)
+    msg_def = """================================================================================
+IDL: geometry_msgs/msg/Transforms
+
+module geometry_msgs {
+  module msg {
+    struct Transforms {
+      sequence<geometry_msgs::msg::TransformStamped> transforms;
+    };
+  };
+};
+================================================================================
+IDL: geometry_msgs/msg/TransformStamped
+
+module geometry_msgs {
+  module msg {
+    struct TransformStamped {
+      std_msgs::msg::Header header;
+      string child_frame_id; // the frame id of the child frame
+      geometry_msgs::msg::Transform transform;
+    };
+  };
+};
+================================================================================
+IDL: std_msgs/msg/Header
+
+module std_msgs {
+  module msg {
+    struct Header {
+      builtin_interfaces::Time stamp;
+      string frame_id;
+    };
+  };
+};
+================================================================================
+IDL: geometry_msgs/msg/Transform
+
+module geometry_msgs {
+  module msg {
+    struct Transform {
+      geometry_msgs::msg::Vector3 translation;
+      geometry_msgs::msg::Quaternion rotation;
+    };
+  };
+};
+
+================================================================================
+IDL: geometry_msgs/msg/Vector3
+
+module geometry_msgs {
+  module msg {
+    struct Vector3 {
+      double x;
+      double y;
+      double z;
+    };
+  };
+};
+
+================================================================================
+IDL: geometry_msgs/msg/Quaternion
+
+module geometry_msgs {
+  module msg {
+    struct Quaternion {
+      double x;
+      double y;
+      double z;
+      double w;
+    };
+  };
+};
+
+================================================================================
+IDL: builtin_interfaces/Time
+// Normally added when generating idl schemas
+
+module builtin_interfaces {
+  struct Time {
+    int32 sec;
+    uint32 nanosec;
+  };
+};
+"""
+    defs = parse_ros2idl(msg_def)
+    reader = MessageReader(defs)
+    read = reader.read_message(buffer)
+    assert read == {
+        "transforms": [
+            {
+                "header": {
+                    "stamp": {"sec": 1638821672, "nanosec": 836230505},
+                    "frame_id": "turtle1",
+                },
+                "child_frame_id": "turtle1_ahead",
+                "transform": {
+                    "translation": {"x": 1.0, "y": 0.0, "z": 0.0},
+                    "rotation": {"x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0},
+                },
+            }
+        ]
+    }
+
+
+def test_ros2idl_root_selection() -> None:
+    data = bytes([0x02])
+    buffer = b"\x00\x01\x00\x00" + data
+    msg_def = """module a {
+  module b {
+    const int8 STATUS_ONE = 1;
+    const int8 STATUS_TWO = 2;
+  };
+  struct c {
+   int8 status;
+  };
+};
+"""
+    defs = parse_ros2idl(msg_def)
+    reader = MessageReader(defs)
+    read = reader.read_message(buffer)
+    assert read == {"status": 2}
+
+
+def test_union_parsing() -> None:
+    idl = """module test {
+  union IntOrString switch(uint8) {
+    case 0: int32 num;
+    case 1: string text;
+  };
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs)
+
+    w = CdrWriter()
+    w.uint8(0)
+    w.int32(42)
+    buffer = w.data
+    assert reader.read_message(buffer) == {"discriminator": 0, "num": 42}
+
+    w = CdrWriter()
+    w.uint8(1)
+    w.string("hello")
+    buffer = w.data
+    assert reader.read_message(buffer) == {"discriminator": 1, "text": "hello"}
+
+
+def test_nested_union_parsing() -> None:
+    idl = """module test {
+  struct Wrapper { IntOrString value; };
+  union IntOrString switch(uint8) {
+    case 0: int32 num;
+    case 1: string text;
+  };
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs)
+
+    w = CdrWriter()
+    w.uint8(1)
+    w.string("hi")
+    buffer = w.data
+    assert reader.read_message(buffer) == {"value": {"discriminator": 1, "text": "hi"}}
+
+
+def test_enum_union_parsing() -> None:
+    idl = """module test {
+  enum Switch { NUM, TEXT };
+  union IntOrString switch(Switch) {
+    case NUM: int32 num;
+    case TEXT: string text;
+  };
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs)
+
+    w = CdrWriter()
+    w.uint32(0)
+    w.int32(99)
+    buffer = w.data
+    assert reader.read_message(buffer) == {"discriminator": 0, "num": 99}
+
+    w = CdrWriter()
+    w.uint32(1)
+    w.string("enum")
+    buffer = w.data
+    assert reader.read_message(buffer) == {"discriminator": 1, "text": "enum"}
+
+
+def test_enum_union_parsing_as_string() -> None:
+    idl = """module test {
+  enum Switch { NUM, TEXT };
+  union IntOrString switch(Switch) {
+    case NUM: int32 num;
+    case TEXT: string text;
+  };
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs, MessageReaderOptions(enumAsString=True))
+
+    w = CdrWriter()
+    w.uint32(0)
+    w.int32(99)
+    buffer = w.data
+    assert reader.read_message(buffer) == {"discriminator": "NUM", "num": 99}
+
+    w = CdrWriter()
+    w.uint32(1)
+    w.string("enum")
+    buffer = w.data
+    assert reader.read_message(buffer) == {"discriminator": "TEXT", "text": "enum"}
+
+
+def test_enum_field_as_string() -> None:
+    idl = """module test {
+  enum Switch { NUM, TEXT };
+  struct Bar { Switch mode; };
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs, MessageReaderOptions(enumAsString=True))
+
+    w = CdrWriter()
+    w.uint32(1)
+    buffer = w.data
+    assert reader.read_message(buffer) == {"mode": "TEXT"}
+
+
+def test_enum_array_field_as_string() -> None:
+    idl = """module test {
+  enum Switch { NUM, TEXT };
+  struct Bar { Switch mode; sequence<Switch> modes; };
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs, MessageReaderOptions(enumAsString=True))
+
+    w = CdrWriter()
+    w.uint32(0)
+    w.uint32(2)
+    w.uint32(1)
+    w.uint32(0)
+    buffer = w.data
+    assert reader.read_message(buffer) == {
+        "mode": "NUM",
+        "modes": ["TEXT", "NUM"],
+    }
+
+
+def test_nested_enum_union_parsing() -> None:
+    idl = """module test {
+  enum Switch { NUM, TEXT };
+  struct Wrapper { IntOrString value; };
+  union IntOrString switch(Switch) {
+    case NUM: int32 num;
+    case TEXT: string text;
+  };
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs)
+
+    w = CdrWriter()
+    w.uint32(1)
+    w.string("nested")
+    buffer = w.data
+    assert reader.read_message(buffer) == {
+        "value": {"discriminator": 1, "text": "nested"}
+    }
+
+
+def test_union_default_case_uint8() -> None:
+    idl = """module test {
+  union IntOrString switch(uint8) {
+    case 0: int32 num;
+    default: string text;
+  };
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs)
+
+    w = CdrWriter()
+    w.uint8(1)
+    w.string("fallback")
+    buffer = w.data
+    assert reader.read_message(buffer) == {"discriminator": 1, "text": "fallback"}
+
+
+def test_enum_union_default_case() -> None:
+    idl = """module test {
+  enum Switch { NUM, TEXT };
+  union IntOrString switch(Switch) {
+    case NUM: int32 num;
+    default: string text;
+  };
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs)
+
+    w = CdrWriter()
+    w.uint32(1)
+    w.string("enum default")
+    buffer = w.data
+    assert reader.read_message(buffer) == {"discriminator": 1, "text": "enum default"}
+
+
+def test_nested_module_enum_union() -> None:
+    idl = """module test {
+  module t2_test_msgs {
+
+  enum FooEnum {
+    ENUMERATOR1,
+    ENUMERATOR2
+  };
+
+  union FooUnion switch(FooEnum) {
+  case ENUMERATOR1:
+    int32 int_value;
+  case ENUMERATOR2:
+    string<32> string_value;
+  };
+
+  module msg {
+     @verbatim (language="comment", text=
+     "This is a comment about the Bar message")
+     struct Bar {
+       FooUnion union_value;  // member is a union discriminated by FooEnum
+       };
+    };
+  };
+
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs)
+
+    w = CdrWriter()
+    w.uint32(1)
+    w.string("Hello!")
+    buffer = w.data
+    assert reader.read_message(buffer) == {
+        "union_value": {"discriminator": 1, "string_value": "Hello!"}
+    }
+
+
+def test_nested_module_enum_union_as_string() -> None:
+    idl = """module test {
+  module t2_test_msgs {
+
+  enum FooEnum {
+    ENUMERATOR1,
+    ENUMERATOR2
+  };
+
+  union FooUnion switch(FooEnum) {
+  case ENUMERATOR1:
+    int32 int_value;
+  case ENUMERATOR2:
+    string<32> string_value;
+  };
+
+  module msg {
+     @verbatim (language="comment", text=
+     "This is a comment about the Bar message")
+     struct Bar {
+       FooUnion union_value;  // member is a union discriminated by FooEnum
+       };
+    };
+  };
+
+};"""
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs, MessageReaderOptions(enumAsString=True))
+
+    w = CdrWriter()
+    w.uint32(1)
+    w.string("Hello!")
+    buffer = w.data
+    assert reader.read_message(buffer) == {
+        "union_value": {"discriminator": "ENUMERATOR2", "string_value": "Hello!"}
+    }
+
+
+@pytest.mark.parametrize("msg_def", ["wstring field", "wstring[] field"])
+def test_wstring_unsupported(msg_def: str) -> None:
+    buffer = bytes.fromhex("00010000000000007b000000")
+    defs = parse(msg_def, ros2=True)
+    reader = MessageReader(defs)
+    with pytest.raises(RuntimeError, match="wstring is implementation-defined"):
+        reader.read_message(buffer)

--- a/tests/python_ros/test_MessageWriter.py
+++ b/tests/python_ros/test_MessageWriter.py
@@ -1,0 +1,540 @@
+# flake8: noqa
+import struct
+
+import pytest
+
+from mcap_ros2idl_support.ros2idl_parser import parse_ros2idl
+from mcap_ros2idl_support.rosmsg2_serialization import MessageWriter
+from mcap_ros2idl_support.rosmsg.parse import parse
+
+
+def _serialize_string(string: str) -> bytes:
+    data = string.encode("utf8")
+    return struct.pack("<I", len(data) + 1) + data + b"\x00"
+
+
+@pytest.mark.parametrize(
+    "primitive,fmt,min_val,max_val",
+    [
+        ("int8", "<b", -128, 127),
+        ("uint8", "<B", 0, 255),
+        ("int16", "<h", -32768, 32767),
+        ("uint16", "<H", 0, 65535),
+        ("int32", "<i", -2147483648, 2147483647),
+        ("uint32", "<I", 0, 4294967295),
+        ("int64", "<q", -9223372036854775808, 9223372036854775807),
+        ("uint64", "<Q", 0, 18446744073709551615),
+    ],
+)
+def test_primitive_bounds(primitive: str, fmt: str, min_val: int, max_val: int) -> None:
+    msg_def = f"{primitive} sample"
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    for val in (min_val, max_val):
+        expected = b"\x00\x01\x00\x00" + struct.pack(fmt, val)
+        written = writer.write_message({"sample": val})
+        assert written == expected
+        assert writer.calculate_byte_size({"sample": val}) == len(expected)
+
+
+@pytest.mark.parametrize(
+    "primitive,fmt,val",
+    [
+        ("float32", "<f", 5.5),
+        ("float64", "<d", 0.123456789121212121212),
+    ],
+)
+def test_float_samples(primitive: str, fmt: str, val: float) -> None:
+    msg_def = f"{primitive} sample"
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    expected = b"\x00\x01\x00\x00" + struct.pack(fmt, val)
+    written = writer.write_message({"sample": val})
+    assert written == expected
+    assert writer.calculate_byte_size({"sample": val}) == len(expected)
+
+
+def test_time_and_duration_fields() -> None:
+    msg_def = """builtin_interfaces/msg/Time stamp
+================================================================================
+MSG: builtin_interfaces/msg/Time
+int32 sec
+uint32 nanosec
+"""
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    message = {"stamp": {"sec": 0, "nsec": 1}}
+    expected = b"\x00\x01\x00\x00" + struct.pack("<iI", 0, 1)
+    written = writer.write_message(message)
+    assert written == expected
+
+    msg_def = """builtin_interfaces/msg/Duration stamp
+================================================================================
+MSG: builtin_interfaces/msg/Duration
+int32 sec
+uint32 nanosec
+"""
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    message = {"stamp": {"sec": 0, "nsec": 1}}
+    expected = b"\x00\x01\x00\x00" + struct.pack("<iI", 0, 1)
+    written = writer.write_message(message)
+    assert written == expected
+
+
+@pytest.mark.parametrize(
+    "msg_def,message,expected",
+    [
+        (
+            "int32[] arr",
+            {"arr": [3, 7]},
+            b"\x00\x01\x00\x00" + struct.pack("<I", 2) + struct.pack("<2i", 3, 7),
+        ),
+        (
+            "uint8 blank\nint32[] arr",
+            {"blank": 0, "arr": [3, 7]},
+            b"\x00\x01\x00\x00"
+            + b"\x00"
+            + b"\x00\x00\x00"
+            + struct.pack("<I", 2)
+            + struct.pack("<2i", 3, 7),
+        ),
+        (
+            "float32[2] arr",
+            {"arr": [5.5, 6.5]},
+            b"\x00\x01\x00\x00" + struct.pack("<2f", 5.5, 6.5),
+        ),
+        (
+            "uint8 blank\nfloat32[2] arr",
+            {"blank": 0, "arr": [5.5, 6.5]},
+            b"\x00\x01\x00\x00"
+            + b"\x00"
+            + b"\x00\x00\x00"
+            + struct.pack("<2f", 5.5, 6.5),
+        ),
+        (
+            "float32[] arr",
+            {"arr": [5.5, 6.5]},
+            b"\x00\x01\x00\x00" + struct.pack("<I", 2) + struct.pack("<2f", 5.5, 6.5),
+        ),
+        (
+            "uint8 blank\nfloat32[] arr",
+            {"blank": 0, "arr": [5.5, 6.5]},
+            b"\x00\x01\x00\x00"
+            + b"\x00"
+            + b"\x00\x00\x00"
+            + struct.pack("<I", 2)
+            + struct.pack("<2f", 5.5, 6.5),
+        ),
+        (
+            "float32[] first\nfloat32[] second",
+            {"first": [5.5, 6.5], "second": [5.5, 6.5]},
+            b"\x00\x01\x00\x00"
+            + struct.pack("<I", 2)
+            + struct.pack("<2f", 5.5, 6.5)
+            + struct.pack("<I", 2)
+            + struct.pack("<2f", 5.5, 6.5),
+        ),
+        (
+            "string sample",
+            {"sample": ""},
+            b"\x00\x01\x00\x00" + _serialize_string(""),
+        ),
+        (
+            "string sample",
+            {"sample": "some string"},
+            b"\x00\x01\x00\x00" + _serialize_string("some string"),
+        ),
+        (
+            "int8[4] first",
+            {"first": [0, -1, -128, 127]},
+            b"\x00\x01\x00\x00" + bytes([0x00, 0xFF, 0x80, 0x7F]),
+        ),
+        (
+            "int8[] first",
+            {"first": [0, -1, -128, 127]},
+            b"\x00\x01\x00\x00"
+            + struct.pack("<I", 4)
+            + bytes([0x00, 0xFF, 0x80, 0x7F]),
+        ),
+        (
+            "uint8[4] first",
+            {"first": [0, 255, 128, 127]},
+            b"\x00\x01\x00\x00" + bytes([0x00, 0xFF, 0x80, 0x7F]),
+        ),
+        (
+            "string[2] first",
+            {"first": ["one", "longer string"]},
+            b"\x00\x01\x00\x00"
+            + _serialize_string("one")
+            + _serialize_string("longer string"),
+        ),
+        (
+            "string[] first",
+            {"first": ["one", "longer string"]},
+            b"\x00\x01\x00\x00"
+            + struct.pack("<I", 2)
+            + _serialize_string("one")
+            + _serialize_string("longer string"),
+        ),
+        (
+            "int8 first\nint8 second",
+            {"first": -128, "second": 127},
+            b"\x00\x01\x00\x00" + bytes([0x80, 0x7F]),
+        ),
+        (
+            "string first\nint8 second",
+            {"first": "some string", "second": -128},
+            b"\x00\x01\x00\x00" + _serialize_string("some string") + bytes([0x80]),
+        ),
+        (
+            """CustomType custom
+================================================================================
+MSG: custom_type/CustomType
+uint8 first
+""",
+            {"custom": {"first": 0x02}},
+            b"\x00\x01\x00\x00" + bytes([0x02]),
+        ),
+        (
+            """CustomType[3] custom
+================================================================================
+MSG: custom_type/CustomType
+uint8 first
+""",
+            {"custom": [{"first": 0x02}, {"first": 0x03}, {"first": 0x04}]},
+            b"\x00\x01\x00\x00" + bytes([0x02, 0x03, 0x04]),
+        ),
+        (
+            """CustomType[] custom
+================================================================================
+MSG: custom_type/CustomType
+uint8 first
+""",
+            {"custom": [{"first": 0x02}, {"first": 0x03}, {"first": 0x04}]},
+            b"\x00\x01\x00\x00" + struct.pack("<I", 3) + bytes([0x02, 0x03, 0x04]),
+        ),
+        (
+            "int8 STATUS_ONE = 1\nint8 STATUS_TWO = 2\nint8 status",
+            {"status": 2},
+            b"\x00\x01\x00\x00" + bytes([0x02]),
+        ),
+        (
+            """CustomType[] custom
+================================================================================
+MSG: custom_type/CustomType
+MoreCustom another
+================================================================================
+MSG: custom_type/MoreCustom
+uint8 field
+""",
+            {
+                "custom": [
+                    {"another": {"field": 0x02}},
+                    {"another": {"field": 0x03}},
+                    {"another": {"field": 0x04}},
+                ]
+            },
+            b"\x00\x01\x00\x00" + struct.pack("<I", 3) + bytes([0x02, 0x03, 0x04]),
+        ),
+    ],
+)
+def test_misc_cases(msg_def: str, message: dict, expected: bytes) -> None:
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    written = writer.write_message(message)
+    assert written == expected
+    assert writer.calculate_byte_size(message) == len(expected)
+
+
+def test_log_message() -> None:
+    hexdata = "00010000fb65865e80faae0614000000120000006d696e696d616c5f7075626c69736865720000001e0000005075626c697368696e673a202748656c6c6f2c20776f726c64212030270000004c0000002f6f70742f726f73325f77732f656c6f7175656e742f7372632f726f73322f6578616d706c65732f72636c6370702f6d696e696d616c5f7075626c69736865722f6c616d6264612e637070000b0000006f70657261746f722829000026000000"
+    buffer = bytes.fromhex(hexdata)
+    msg_def = """byte DEBUG=10
+byte INFO=20
+byte WARN=30
+byte ERROR=40
+byte FATAL=50
+##
+## Fields
+##
+builtin_interfaces/Time stamp
+uint8 level
+string name # name of the node
+string msg # message
+string file # file the message came from
+string function # function the message came from
+uint32 line # line the message came from
+"""
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    message = {
+        "stamp": {"sec": 1585866235, "nsec": 112130688},
+        "level": 20,
+        "name": "minimal_publisher",
+        "msg": "Publishing: 'Hello, world! 0'",
+        "file": "/opt/ros2_ws/eloquent/src/ros2/examples/rclcpp/minimal_publisher/lambda.cpp",
+        "function": "operator()",
+        "line": 38,
+    }
+    written = writer.write_message(message)
+    assert written == buffer
+    assert writer.calculate_byte_size(message) == len(buffer)
+
+
+def test_tf_message() -> None:
+    hexdata = "0001000001000000286fae6169ddd73108000000747572746c6531000e000000747572746c65315f616865616400000000000000000000000000f03f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f03f"
+    buffer = bytes.fromhex(hexdata)
+    msg_def = """geometry_msgs/TransformStamped[] transforms
+================================================================================
+MSG: geometry_msgs/TransformStamped
+Header header
+string child_frame_id # the frame id of the child frame
+Transform transform
+================================================================================
+MSG: std_msgs/Header
+builtin_interfaces/Time stamp
+string frame_id
+================================================================================
+MSG: geometry_msgs/Transform
+Vector3 translation
+Quaternion rotation
+================================================================================
+MSG: geometry_msgs/Vector3
+float64 x
+float64 y
+float64 z
+================================================================================
+MSG: geometry_msgs/Quaternion
+float64 x
+float64 y
+float64 z
+float64 w
+"""
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    message = {
+        "transforms": [
+            {
+                "header": {
+                    "stamp": {"sec": 1638821672, "nsec": 836230505},
+                    "frame_id": "turtle1",
+                },
+                "child_frame_id": "turtle1_ahead",
+                "transform": {
+                    "translation": {"x": 1, "y": 0, "z": 0},
+                    "rotation": {"x": 0, "y": 0, "z": 0, "w": 1},
+                },
+            }
+        ]
+    }
+    written = writer.write_message(message)
+    assert written == buffer
+    assert writer.calculate_byte_size(message) == len(buffer)
+
+
+def test_ros2idl_tf_message() -> None:
+    hexdata = "0001000001000000286fae6169ddd73108000000747572746c6531000e000000747572746c65315f616865616400000000000000000000000000f03f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f03f"
+    buffer = bytes.fromhex(hexdata)
+    msg_def = """================================================================================
+IDL: geometry_msgs/msg/Transforms
+
+module geometry_msgs {
+  module msg {
+    struct Transforms {
+      sequence<geometry_msgs::msg::TransformStamped> transforms;
+    };
+  };
+};
+================================================================================
+IDL: geometry_msgs/msg/TransformStamped
+
+module geometry_msgs {
+  module msg {
+    struct TransformStamped {
+      std_msgs::msg::Header header;
+      string child_frame_id; // the frame id of the child frame
+      geometry_msgs::msg::Transform transform;
+    };
+  };
+};
+================================================================================
+IDL: std_msgs/msg/Header
+
+module std_msgs {
+  module msg {
+    struct Header {
+      builtin_interfaces::Time stamp;
+      string frame_id;
+    };
+  };
+};
+================================================================================
+IDL: geometry_msgs/msg/Transform
+
+module geometry_msgs {
+  module msg {
+    struct Transform {
+      geometry_msgs::msg::Vector3 translation;
+      geometry_msgs::msg::Quaternion rotation;
+    };
+  };
+};
+
+================================================================================
+IDL: geometry_msgs/msg/Vector3
+
+module geometry_msgs {
+  module msg {
+    struct Vector3 {
+      double x;
+      double y;
+      double z;
+    };
+  };
+};
+
+================================================================================
+IDL: geometry_msgs/msg/Quaternion
+
+module geometry_msgs {
+  module msg {
+    struct Quaternion {
+      double x;
+      double y;
+      double z;
+      double w;
+    };
+  };
+};
+
+================================================================================
+IDL: builtin_interfaces/Time
+// Normally added when generating idl schemas
+
+module builtin_interfaces {
+  struct Time {
+    int32 sec;
+    uint32 nanosec;
+  };
+};
+"""
+    defs = parse_ros2idl(msg_def)
+    writer = MessageWriter(defs)
+    message = {
+        "transforms": [
+            {
+                "header": {
+                    "stamp": {"sec": 1638821672, "nanosec": 836230505},
+                    "frame_id": "turtle1",
+                },
+                "child_frame_id": "turtle1_ahead",
+                "transform": {
+                    "translation": {"x": 1, "y": 0, "z": 0},
+                    "rotation": {"x": 0, "y": 0, "z": 0, "w": 1},
+                },
+            }
+        ]
+    }
+    written = writer.write_message(message)
+    assert written == buffer
+    assert writer.calculate_byte_size(message) == len(buffer)
+
+
+def test_empty_message_and_empty_fields() -> None:
+    defs = parse("", ros2=True)
+    writer = MessageWriter(defs)
+    assert writer.write_message({}) == b"\x00\x01\x00\x00\x00"
+
+    msg_def = """std_msgs/msg/Empty empty
+uint8 uint_8_field
+================================================================================
+MSG: std_msgs/msg/Empty
+"""
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    message = {"uint_8_field": 123}
+    expected = bytes.fromhex("00010000007b")
+    assert writer.write_message(message) == expected
+
+    msg_def = """std_msgs/msg/Empty empty
+int32 int_32_field
+================================================================================
+MSG: std_msgs/msg/Empty
+"""
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    message = {"int_32_field": 16777339}
+    expected = bytes.fromhex("00010000000000007b000001")
+    assert writer.write_message(message) == expected
+
+    msg_def = """custom_msgs/msg/Nothing empty
+int32 int_32_field
+================================================================================
+MSG: custom_msgs/msg/Nothing
+int32 EXAMPLE=123
+"""
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    message = {"int_32_field": 16777339}
+    expected = bytes.fromhex("00010000000000007b000001")
+    assert writer.write_message(message) == expected
+
+
+def test_ros2idl_root_selection() -> None:
+    message = {"status": 2}
+    message_bin = bytes([0x02])
+    msg_def = """module a {
+  module b {
+    const int8 STATUS_ONE = 1;
+    const int8 STATUS_TWO = 2;
+  };
+  struct c {
+   int8 status;
+  };
+};
+"""
+    defs = parse_ros2idl(msg_def)
+    writer = MessageWriter(defs)
+    expected = b"\x00\x01\x00\x00" + message_bin
+    written = writer.write_message(message)
+    assert written == expected
+    assert writer.calculate_byte_size(message) == len(expected)
+
+
+@pytest.mark.parametrize(
+    "type_,length,expected_len",
+    [("float64", 10, 84), ("time", 10, 84), ("uint8", 5, 9)],
+)
+def test_default_initialization_fixed_arrays(
+    type_: str, length: int, expected_len: int
+) -> None:
+    msg_def = f"{type_}[{length}] array"
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    written = writer.write_message({})
+    assert len(written) == expected_len
+
+
+def test_fixed_array_size_validation() -> None:
+    from array import array as arr
+
+    msg_def = "float64[10] array"
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    with pytest.raises(ValueError):
+        writer.write_message({"array": []})
+    with pytest.raises(ValueError):
+        writer.write_message({"array": arr("d")})
+    with pytest.raises(ValueError):
+        writer.write_message({"array": arr("d", [0] * 5)})
+    writer.write_message({"array": arr("d", [0] * 10)})
+    writer.write_message({"array": [0] * 10})
+
+
+@pytest.mark.parametrize("msg_def", ["wstring field", "wstring[10] field"])
+def test_wstring_unsupported(msg_def: str) -> None:
+    defs = parse(msg_def, ros2=True)
+    writer = MessageWriter(defs)
+    with pytest.raises(RuntimeError, match="wstring is implementation-defined"):
+        writer.write_message({"field": []})

--- a/tests/python_ros/test_md5.py
+++ b/tests/python_ros/test_md5.py
@@ -1,0 +1,79 @@
+# flake8: noqa
+from mcap_ros2idl_support.rosmsg import md5, parse
+
+MD5_TESTS = [
+    ("std_msgs/Bool", "bool data", "8b94c1b53db61fb6aed406028ad6332a"),
+    ("Int8Array", "int8[] data", "ac9c931aaf6ce145ea0383362e83c70b"),
+    ("BoolFalseConstant", "bool A=False", "d3011fbf97518e43e51a9ef7f5f352f1"),
+    (
+        "sensor_msgs/PointCloud2",
+        """# This message holds a collection of N-dimensional points, which may
+  # contain additional information such as normals, intensity, etc. The
+  # point data is stored as a binary blob, its layout described by the
+  # contents of the \"fields\" array.
+
+  # The point cloud data may be organized 2d (image-like) or 1d
+  # (unordered). Point clouds organized as 2d images may be produced by
+  # camera depth sensors such as stereo or time-of-flight.
+
+  # Time of sensor data acquisition, and the coordinate frame ID (for 3d
+  # points).
+  Header header
+
+  # 2D structure of the point cloud. If the cloud is unordered, height is
+  # 1 and width is the length of the point cloud.
+  uint32 height
+  uint32 width
+
+  # Describes the channels and their layout in the binary data blob.
+  PointField[] fields
+
+  bool    is_bigendian # Is this data bigendian?
+  uint32  point_step   # Length of a point in bytes
+  uint32  row_step     # Length of a row in bytes
+  uint8[] data         # Actual point data, size is (row_step*height)
+
+  bool is_dense        # True if there are no invalid points
+
+  =============================================================================
+  MSG: std_msgs/Header
+  # Standard metadata for higher-level stamped data types.
+  # This is generally used to communicate timestamped data
+  # in a particular coordinate frame.
+  #
+  # sequence ID: consecutively increasing ID
+  uint32 seq
+  #Two-integer timestamp that is expressed as:
+  # * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+  # * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+  # time-handling sugar is provided by the client library
+  time stamp
+  #Frame this data is associated with
+  string frame_id
+
+  =============================================================================
+  MSG: sensor_msgs/PointField
+  # This message holds the description of one point entry in the
+  # PointCloud2 message format.
+  uint8 INT8    = 1
+  uint8 UINT8   = 2
+  uint8 INT16   = 3
+  uint8 UINT16  = 4
+  uint8 INT32   = 5
+  uint8 UINT32  = 6
+  uint8 FLOAT32 = 7
+  uint8 FLOAT64 = 8
+
+  string name      # Name of field
+  uint32 offset    # Offset from start of point struct
+  uint8  datatype  # Datatype enumeration, see above
+  uint32 count     # How many elements in the field
+  """,
+        "1158d486dd51d683ce2f1be655c3c181",
+    ),
+]
+
+
+def test_md5():
+    for _name, msg_def, expected in MD5_TESTS:
+        assert md5(parse(msg_def)) == expected

--- a/tests/python_ros/test_parse_ros1.py
+++ b/tests/python_ros/test_parse_ros1.py
@@ -1,0 +1,242 @@
+from mcap_ros2idl_support.message_definition import (
+    MessageDefinition,
+    MessageDefinitionField,
+)
+from mcap_ros2idl_support.rosmsg.parse import fixup_types, parse
+
+
+def test_parses_single_field():
+    assert parse("string name") == [
+        MessageDefinition(
+            name=None, definitions=[MessageDefinitionField(type="string", name="name")]
+        )
+    ]
+
+
+def test_resolves_unqualified_names():
+    message_definition = (
+        "Point[] points\n" "===============\n" "MSG: geometry_msgs/Point\n" "float64 x"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="geometry_msgs/Point",
+                    name="points",
+                    isArray=True,
+                    isComplex=True,
+                )
+            ],
+        ),
+        MessageDefinition(
+            name="geometry_msgs/Point",
+            definitions=[MessageDefinitionField(type="float64", name="x")],
+        ),
+    ]
+
+
+def test_normalizes_aliases():
+    assert parse("char x\nbyte y") == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="uint8", name="x"),
+                MessageDefinitionField(type="int8", name="y"),
+            ],
+        )
+    ]
+
+
+def test_ignores_comment_lines():
+    message_definition = (
+        "# your first name goes here\n"
+        "string firstName\n\n"
+        "# last name here\n"
+        "### foo bar baz?\n"
+        "string lastName\n"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="firstName"),
+                MessageDefinitionField(type="string", name="lastName"),
+            ],
+        )
+    ]
+
+
+def test_parses_variable_length_array():
+    assert parse("string[] names") == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="names", isArray=True)
+            ],
+        )
+    ]
+
+
+def test_parses_fixed_length_array():
+    assert parse("string[3] names") == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="string", name="names", isArray=True, arrayLength=3
+                )
+            ],
+        )
+    ]
+
+
+def test_parses_nested_complex_types():
+    message_definition = (
+        "string username\n"
+        "Account account\n"
+        "===============\n"
+        "MSG: custom_type/Account\n"
+        "string name\n"
+        "uint16 id"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="username"),
+                MessageDefinitionField(
+                    type="custom_type/Account", name="account", isComplex=True
+                ),
+            ],
+        ),
+        MessageDefinition(
+            name="custom_type/Account",
+            definitions=[
+                MessageDefinitionField(type="string", name="name"),
+                MessageDefinitionField(type="uint16", name="id"),
+            ],
+        ),
+    ]
+
+
+def test_returns_constants():
+    message_definition = (
+        "uint32 foo = 55\n"
+        "int32 bar=-11\n"
+        "float32 baz= -32.25\n"
+        "bool someBoolean = 0\n"
+        "string fooStr = Foo\n"
+        "int64 A = 0000000000000001"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="uint32", name="foo", isConstant=True, valueText="55"
+                ),
+                MessageDefinitionField(
+                    type="int32", name="bar", isConstant=True, valueText="-11"
+                ),
+                MessageDefinitionField(
+                    type="float32", name="baz", isConstant=True, valueText="-32.25"
+                ),
+                MessageDefinitionField(
+                    type="bool", name="someBoolean", isConstant=True, valueText="0"
+                ),
+                MessageDefinitionField(
+                    type="string", name="fooStr", isConstant=True, valueText="Foo"
+                ),
+                MessageDefinitionField(
+                    type="int64",
+                    name="A",
+                    isConstant=True,
+                    valueText="0000000000000001",
+                ),
+            ],
+        )
+    ]
+
+
+def test_handles_python_boolean_values():
+    message_definition = "bool Alive=True\n" "bool Dead=False"
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="bool", name="Alive", isConstant=True, valueText="True"
+                ),
+                MessageDefinitionField(
+                    type="bool", name="Dead", isConstant=True, valueText="False"
+                ),
+            ],
+        )
+    ]
+
+
+def test_handles_type_names_for_fields():
+    assert parse("time time") == [
+        MessageDefinition(
+            name=None,
+            definitions=[MessageDefinitionField(type="time", name="time")],
+        )
+    ]
+
+    assert parse("time time_ref") == [
+        MessageDefinition(
+            name=None,
+            definitions=[MessageDefinitionField(type="time", name="time_ref")],
+        )
+    ]
+
+    message_definition = (
+        "true true\n" "===============\n" "MSG: custom/true\n" "bool false"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="custom/true", name="true", isComplex=True)
+            ],
+        ),
+        MessageDefinition(
+            name="custom/true",
+            definitions=[MessageDefinitionField(type="bool", name="false")],
+        ),
+    ]
+
+
+def test_allows_numbers_in_package_names():
+    message_definition = (
+        "abc1/Foo2 value0\n" "==========\n" "MSG: abc1/Foo2\n" "int32 data"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="abc1/Foo2", name="value0", isComplex=True)
+            ],
+        ),
+        MessageDefinition(
+            name="abc1/Foo2",
+            definitions=[MessageDefinitionField(type="int32", name="data")],
+        ),
+    ]
+
+
+def test_fixup_types_empty_list():
+    types: list[MessageDefinition] = []
+    fixup_types(types)
+    assert types == []
+
+
+def test_fixup_types_rewrites_names():
+    message_definition = (
+        "Point[] points\n" "===============\n" "MSG: geometry_msgs/Point\n" "float64 x"
+    )
+    types = parse(message_definition, skip_type_fixup=True)
+    assert types[0].definitions[0].type == "Point"
+    fixup_types(types)
+    assert types[0].definitions[0].type == "geometry_msgs/Point"

--- a/tests/python_ros/test_parse_ros2.py
+++ b/tests/python_ros/test_parse_ros2.py
@@ -1,0 +1,237 @@
+from mcap_ros2idl_support.message_definition import (
+    MessageDefinition,
+    MessageDefinitionField,
+)
+from mcap_ros2idl_support.rosmsg.parse import parse
+
+
+def test_parses_single_field():
+    assert parse("string name", ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[MessageDefinitionField(type="string", name="name")],
+        )
+    ]
+
+
+def test_resolves_unqualified_names():
+    message_definition = (
+        "Point[] points\n" "===============\n" "MSG: geometry_msgs/Point\n" "float64 x"
+    )
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="geometry_msgs/Point",
+                    name="points",
+                    isArray=True,
+                    isComplex=True,
+                )
+            ],
+        ),
+        MessageDefinition(
+            name="geometry_msgs/Point",
+            definitions=[MessageDefinitionField(type="float64", name="x")],
+        ),
+    ]
+
+
+def test_normalizes_aliases():
+    assert parse("char x\nbyte y", ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="uint8", name="x"),
+                MessageDefinitionField(type="uint8", name="y"),
+            ],
+        )
+    ]
+
+
+def test_ignores_comment_lines():
+    message_definition = (
+        "# your first name goes here\n"
+        "string first_name\n\n"
+        "# last name here\n"
+        "### foo bar baz?\n"
+        "string last_name\n"
+    )
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="first_name"),
+                MessageDefinitionField(type="string", name="last_name"),
+            ],
+        )
+    ]
+
+
+def test_parses_variable_length_array():
+    assert parse("string[] names", ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="names", isArray=True)
+            ],
+        )
+    ]
+
+
+def test_parses_fixed_length_array():
+    assert parse("string[3] names", ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="string", name="names", isArray=True, arrayLength=3
+                )
+            ],
+        )
+    ]
+
+
+def test_parses_nested_complex_types():
+    message_definition = (
+        "string username\n"
+        "Account account\n"
+        "===============\n"
+        "MSG: custom_type/Account\n"
+        "string name\n"
+        "uint16 id"
+    )
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="username"),
+                MessageDefinitionField(
+                    type="custom_type/Account", name="account", isComplex=True
+                ),
+            ],
+        ),
+        MessageDefinition(
+            name="custom_type/Account",
+            definitions=[
+                MessageDefinitionField(type="string", name="name"),
+                MessageDefinitionField(type="uint16", name="id"),
+            ],
+        ),
+    ]
+
+
+def test_returns_constants():
+    message_definition = (
+        "uint32 FOO = 55\n"
+        "int32 BAR=-11\n"
+        "float32 BAZ= -32.25\n"
+        "bool SOME_BOOLEAN = 0\n"
+        "string FOO_STR = Foo\n"
+        "int64 A = 0000000000000001"
+    )
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="uint32",
+                    name="FOO",
+                    isConstant=True,
+                    value=55,
+                    valueText="55",
+                ),
+                MessageDefinitionField(
+                    type="int32",
+                    name="BAR",
+                    isConstant=True,
+                    value=-11,
+                    valueText="-11",
+                ),
+                MessageDefinitionField(
+                    type="float32",
+                    name="BAZ",
+                    isConstant=True,
+                    value=-32.25,
+                    valueText="-32.25",
+                ),
+                MessageDefinitionField(
+                    type="bool",
+                    name="SOME_BOOLEAN",
+                    isConstant=True,
+                    value=False,
+                    valueText="0",
+                ),
+                MessageDefinitionField(
+                    type="string",
+                    name="FOO_STR",
+                    isConstant=True,
+                    value="Foo",
+                    valueText="Foo",
+                ),
+                MessageDefinitionField(
+                    type="int64",
+                    name="A",
+                    isConstant=True,
+                    value=1,
+                    valueText="0000000000000001",
+                ),
+            ],
+        )
+    ]
+
+
+def test_handles_python_boolean_values():
+    message_definition = "bool ALIVE=True\n" "bool DEAD=False"
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="bool",
+                    name="ALIVE",
+                    isConstant=True,
+                    value=True,
+                    valueText="True",
+                ),
+                MessageDefinitionField(
+                    type="bool",
+                    name="DEAD",
+                    isConstant=True,
+                    value=False,
+                    valueText="False",
+                ),
+            ],
+        )
+    ]
+
+
+def test_handles_type_names_for_fields():
+    assert parse("time time", ros2=True) == [
+        MessageDefinition(
+            name=None, definitions=[MessageDefinitionField(type="time", name="time")]
+        )
+    ]
+
+    assert parse("time time_ref", ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[MessageDefinitionField(type="time", name="time_ref")],
+        )
+    ]
+
+    message_definition = (
+        "true true\n" "===============\n" "MSG: custom/true\n" "bool false"
+    )
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="custom/true", name="true", isComplex=True)
+            ],
+        ),
+        MessageDefinition(
+            name="custom/true",
+            definitions=[MessageDefinitionField(type="bool", name="false")],
+        ),
+    ]

--- a/tests/python_ros/test_rostime.py
+++ b/tests/python_ros/test_rostime.py
@@ -1,0 +1,67 @@
+import datetime
+
+import mcap_ros2idl_support.rostime as rostime
+
+
+def test_is_time():
+    assert not rostime.is_time(None)
+    assert not rostime.is_time(True)
+    assert not rostime.is_time({"sec": 1})
+    assert not rostime.is_time({"nsec": 1})
+    assert not rostime.is_time({"sec": 1, "nsec": 1, "other": 0})
+    assert rostime.is_time({"sec": 0, "nsec": 0})
+    assert rostime.is_time(rostime.Time(1, 0))
+
+
+def test_rfc3339_roundtrip():
+    t = rostime.Time(sec=1632939128, nsec=123456789)
+    text = rostime.to_rfc3339_string(t)
+    assert text == "2021-09-29T18:12:08.123456789Z"
+    assert rostime.from_rfc3339_string(text) == t
+
+
+def test_to_from_string():
+    t = rostime.Time(10, 5)
+    s = rostime.to_string(t)
+    assert s == "10.000000005"
+    assert rostime.from_string(s) == t
+
+
+def test_conversions():
+    t = rostime.Time(1, 500000000)
+    assert rostime.to_sec(t) == 1.5
+    assert rostime.from_sec(1.5) == t
+    assert rostime.to_nanosec(t) == 1_500_000_000
+    assert rostime.from_nanosec(1_500_000_000) == t
+    assert rostime.to_millis(t) == 1500
+    assert rostime.from_millis(1500) == t
+    assert rostime.from_micros(1_500_000) == t
+
+
+def test_clamp_and_compare():
+    start = rostime.Time(0, 100)
+    end = rostime.Time(100, 100)
+    before = rostime.Time(0, 99)
+    after = rostime.Time(100, 101)
+    assert rostime.clamp_time(before, start, end) == start
+    assert rostime.clamp_time(after, start, end) == end
+    assert rostime.is_time_in_range_inclusive(start, start, end)
+    assert not rostime.is_time_in_range_inclusive(before, start, end)
+    assert rostime.compare(start, end) < 0
+    assert rostime.is_less_than(start, end)
+    assert rostime.is_greater_than(end, start)
+    assert rostime.are_equal(start, rostime.Time(0, 100))
+
+
+def test_percent_of_and_interpolate():
+    start = rostime.Time(0, 0)
+    end = rostime.Time(10, 0)
+    middle = rostime.Time(5, 0)
+    assert rostime.percent_of(start, end, middle) == 0.5
+    assert rostime.interpolate(start, end, 0.5) == middle
+
+
+def test_date_roundtrip():
+    dt = datetime.datetime(2021, 9, 29, 18, 12, 8, 123000, tzinfo=datetime.timezone.utc)
+    t = rostime.from_date(dt)
+    assert rostime.to_date(t) == dt

--- a/tests/python_ros/test_stringify.py
+++ b/tests/python_ros/test_stringify.py
@@ -1,0 +1,82 @@
+from mcap_ros2idl_support.rosmsg import parse, stringify
+
+
+def test_round_trip_definition():
+    message_definition = (
+        "uint32 foo = 55\n"
+        "int32 bar=-11 # Comment # another comment\n"
+        "string test\n"
+        "float32 baz= \t -32.25\n"
+        "bool someBoolean = 0\n"
+        "Point[] points\n"
+        "int64 A = 0000000000000001\n"
+        "string fooStr = Foo    \n"
+        'string EXAMPLE="Hello world"\n'
+        "===============\n"
+        "MSG: geometry_msgs/Point\n"
+        "float64 x"
+    )
+    types = parse(message_definition)
+    output = stringify(types)
+    assert (
+        output == "uint32 foo = 55\n"
+        "int32 bar = -11\n"
+        "float32 baz = -32.25\n"
+        "bool someBoolean = 0\n"
+        "int64 A = 0000000000000001\n"
+        "string fooStr = Foo\n"
+        'string EXAMPLE = "Hello world"\n'
+        "\n"
+        "string test\n"
+        "geometry_msgs/Point[] points\n"
+        "\n"
+        "================================================================================\n"  # noqa: E501
+        "MSG: geometry_msgs/Point\n"
+        "\n"
+        "float64 x"
+    )
+
+
+def test_ros2_features():
+    message_definition = (
+        "string<=5 str1 'abc'\n"
+        'string str2 "def"\n'
+        "int8[<=2] arr1 [ 1 ,-1 ]    \n"
+        "string<=1[<=3] arr2   # comment\n"
+        "bool a  true\n"
+        "float32 b  -1.0\n"
+        "float64 c  42.42\n"
+        "int8 d -100\n"
+        "uint8 e 100\n"
+        "int16 f -1000\n"
+        "uint16 g 1000\n"
+        "int32 h -100000\n"
+        "uint32 i 100000\n"
+        "int64 j -5000000000\n"
+        "uint64 k 5000000000\n"
+        'string my_string1 "I heard \\"Hello\\""# is valid\n'
+        "string my_string2 \"I heard 'Hello'\" # is valid\n"
+        "string my_string4 'I heard \"Hello\"'   # is valid\n"
+    )
+    types = parse(message_definition, ros2=True)
+    output = stringify(types)
+    assert (
+        output == 'string<=5 str1 "abc"\n'
+        'string str2 "def"\n'
+        "int8[<=2] arr1 [1, -1]\n"
+        "string<=1[<=3] arr2\n"
+        "bool a true\n"
+        "float32 b -1\n"
+        "float64 c 42.42\n"
+        "int8 d -100\n"
+        "uint8 e 100\n"
+        "int16 f -1000\n"
+        "uint16 g 1000\n"
+        "int32 h -100000\n"
+        "uint32 i 100000\n"
+        "int64 j -5000000000\n"
+        "uint64 k 5000000000\n"
+        'string my_string1 "I heard \\"Hello\\""\n'
+        "string my_string2 \"I heard 'Hello'\"\n"
+        'string my_string4 "I heard \\"Hello\\""'
+    )

--- a/tests/test_message_reader.py
+++ b/tests/test_message_reader.py
@@ -1,9 +1,8 @@
 import struct
 
-from ros2idl_parser import parse_ros2idl
-from rosmsg import parse
-
 from mcap_ros2idl_support import MessageReader, MessageReaderOptions
+from mcap_ros2idl_support.ros2idl_parser import parse_ros2idl
+from mcap_ros2idl_support.rosmsg import parse
 
 
 def test_enum_with_uint32():


### PR DESCRIPTION
## Summary
- vendor rosmsg, rosmsg2_serialization, rostime, message_definition, omgidl_parser, ros2idl_parser, and cdr packages into mcap_ros2idl_support
- update decode factory and tests to import vendored modules
- drop external rosmsg dependency and add lark and typing-extensions

## Testing
- `pre-commit run --files $(git ls-files -m -o --exclude-standard)`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_b_689fa81f12508328a04844935e06baf9