### PR TITLE
docs: clarify usage and remove rust notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,8 @@ It extracts schemas from rosbag2 messages and decodes their CDR payloads.
 
 ## Features
 
-- Read-only parsing of MCAP/rosbag2 files without needing a ROS 2 runtime
+- Parse MCAP/rosbag2 files without needing a ROS 2 runtime
 - Treats each struct as a Python `dict` instead of generating dynamic classes
-
-## Project structure
-
-The repository is organized as follows:
-
-- `mcap_ros2idl_support/` – core Python package
-  - `cdr/` – helpers for reading and writing CDR streams
-  - `ros2idl_parser/` – parser for `ros2idl` schema definitions
-  - `rosmsg/` – parser for classic `.msg` message definitions
-  - `rosmsg2_serialization/` – utilities for decoding CDR payloads into dictionaries
-  - `decode_factory.py` – integrates parsers and CDR readers with the MCAP decoder
-- `examples/` – example CLI demonstrating how to iterate decoded messages
-- `tests/` – unit tests for the library
 
 ## Installation
 
@@ -30,6 +17,35 @@ Install the Python package:
 
 ```bash
 pip install .
+```
+
+## Usage
+
+### Python example
+
+```python
+from mcap.reader import make_reader
+from mcap_ros2idl_support import Ros2DecodeFactory
+
+factory = Ros2DecodeFactory()
+
+with open("sample.mcap", "rb") as f:
+    reader = make_reader(f, decoder_factories=[factory])
+    for decoded in reader.iter_decoded_messages():
+        print(decoded.channel.topic)
+        print(decoded.decoded_message)
+```
+
+### Command line
+
+```bash
+python examples/cli.py --mcap-file sample.mcap
+```
+
+Use the ``--enum-as-string`` flag to return enumeration values as strings:
+
+```bash
+python examples/cli.py --mcap-file sample.mcap --enum-as-string
 ```
 
 ## Development
@@ -47,13 +63,7 @@ pip install .
    pip install -e '.[dev]'
    ```
 
-3. Build the Rust Python bindings using `maturin`:
-
-   ```bash
-   maturin develop --manifest-path rust/mcap-rs/Cargo.toml
-   ```
-
-4. Install and run `pre-commit`:
+3. Install and run `pre-commit`:
 
    ```bash
    pre-commit install
@@ -66,23 +76,11 @@ pip install .
    pre-commit run --all-files
    ```
 
-5. Run tests with `pytest`:
+4. Run tests with `pytest`:
 
    ```bash
    pytest
    ```
-
-## Usage
-
-```bash
-python examples/cli.py --mcap-file sample.mcap
-```
-
-Use the ``--enum-as-string`` flag to return enumeration values as strings:
-
-```bash
-python examples/cli.py --mcap-file sample.mcap --enum-as-string
-```
 
 ## Building the wheel
 
@@ -104,23 +102,36 @@ python examples/cli.py --mcap-file sample.mcap --enum-as-string
    python -m build
    ```
 
-5. (Optional) Verify the wheel locally:
+4. (Optional) Verify the wheel locally:
 
    ```bash
    python -m pip install dist/mcap_ros2idl_support-<version>-py3-none-any.whl
    ```
 
-6. (Optional) Upload to PyPI:
+5. (Optional) Upload to PyPI:
 
    ```bash
    python -m pip install --upgrade twine
    python -m twine upload dist/*
    ```
 
+## Project structure
+
+The repository is organized as follows:
+
+- `mcap_ros2idl_support/` – core Python package
+  - `cdr/` – helpers for reading and writing CDR streams
+  - `ros2idl_parser/` – parser for `ros2idl` schema definitions
+  - `rosmsg/` – parser for classic `.msg` message definitions
+  - `rosmsg2_serialization/` – utilities for decoding CDR payloads into dictionaries
+  - `decode_factory.py` – integrates parsers and CDR readers with the MCAP decoder
+- `examples/` – example CLI demonstrating how to iterate decoded messages
+- `tests/` – unit tests for the library
+
 ## Design notes
 
 - Uses Foxglove’s `@foxglove/ros2idl-parser` to handle `.idl` files in addition to classic `.msg` definitions.
-- Only reading is supported; writing MCAP files is out of scope.
+- MCAP file writing is out of scope, though helpers exist to encode CDR messages.
 - Enumerations defined in IDL can be returned as their string values by
   enabling ``enum_as_string``.
 - The goal is to enable parsing MCAP bags without any ROS 2 dependencies to make offline analysis easier.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The repository is organized as follows:
 ## Design notes
 
 - Uses Foxglove’s `@foxglove/ros2idl-parser` to handle `.idl` files in addition to classic `.msg` definitions.
-- MCAP file writing is out of scope, though helpers exist to encode CDR messages.
+- MCAP file writing is not supported, though CDR encoding helpers are available for individual messages.
 - Enumerations defined in IDL can be returned as their string values by
   enabling ``enum_as_string``.
 - The goal is to enable parsing MCAP bags without any ROS 2 dependencies to make offline analysis easier.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It extracts schemas from rosbag2 messages and decodes their CDR payloads.
 
 ## Features
 
-- Parse MCAP/rosbag2 files without needing a ROS 2 runtime
+- Read-only parsing of MCAP/rosbag2 files without needing a ROS 2 runtime
 - Treats each struct as a Python `dict` instead of generating dynamic classes
 
 ## Installation


### PR DESCRIPTION
## Summary
- remove outdated rust/maturin instructions from development section
- add python and command line usage examples
- tidy wheel build steps and move usage before development with project structure at end
- clarify that MCAP file writing isn't supported but CDR encoding helpers exist

## Testing
- `pre-commit run --files README.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'mcap')*

------
https://chatgpt.com/codex/tasks/task_b_68a31c5f304c83288a01bb236d9acb15