### PR TITLE
Support deferred constant resolution in IDL parser

### DIFF
--- a/mcap_ros2idl_support/omgidl_parser/parse.py
+++ b/mcap_ros2idl_support/omgidl_parser/parse.py
@@ -388,7 +388,9 @@ class _Transformer(Transformer):
         if not unresolved:
             total = expr_items[0]
             for val in expr_items[1:]:
-                if not isinstance(total, (int, float)) or not isinstance(val, (int, float)):
+                if not isinstance(total, (int, float)) or not isinstance(
+                    val, (int, float)
+                ):
                     raise ValueError("Addition only allowed on numeric constants")
                 total += val
             return total
@@ -500,9 +502,7 @@ class _Transformer(Transformer):
                     if not isinstance(total, (int, float)) or not isinstance(
                         val, (int, float)
                     ):
-                        raise ValueError(
-                            "Addition only allowed on numeric constants"
-                        )
+                        raise ValueError("Addition only allowed on numeric constants")
                     total += val
             return total
         if isinstance(expr, str):
@@ -524,7 +524,9 @@ class _Transformer(Transformer):
     def resolve_constants(
         self, definitions: List[Struct | Module | Constant | Enum | Typedef | Union]
     ) -> None:
-        def resolve_defs(defs: List[Struct | Module | Constant | Enum | Typedef | Union]):
+        def resolve_defs(
+            defs: List[Struct | Module | Constant | Enum | Typedef | Union],
+        ):
             for d in defs:
                 if isinstance(d, Constant):
                     d.value = self._eval_expr(d.value)
@@ -535,9 +537,7 @@ class _Transformer(Transformer):
                             f.sequence_bound
                         )
                 elif isinstance(d, Typedef):
-                    d.sequence_bound = self._resolve_sequence_bound(
-                        d.sequence_bound
-                    )
+                    d.sequence_bound = self._resolve_sequence_bound(d.sequence_bound)
                 elif isinstance(d, Union):
                     for case in d.cases:
                         case.field.sequence_bound = self._resolve_sequence_bound(

--- a/mcap_ros2idl_support/omgidl_parser/parse.py
+++ b/mcap_ros2idl_support/omgidl_parser/parse.py
@@ -267,14 +267,6 @@ class _Transformer(Transformer):
     def sequence_type(self, items):
         inner = items[0]
         bound = items[1] if len(items) > 1 else None
-        if bound is not None:
-            try:
-                bound = int(bound)
-            except ValueError:
-                raise ValueError(
-                    f"Invalid sequence bound value '{bound}'"
-                    " in IDL. Expected an integer."
-                )
         return ("sequence", inner, bound)
 
     def string_type(self, items):
@@ -380,23 +372,33 @@ class _Transformer(Transformer):
         return float(token)
 
     def const_sum(self, items):
-        total = None
-        for idx, item in enumerate(items):
+        expr_items: list[Any] = []
+        unresolved = False
+        for item in items:
             if isinstance(item, str):
-                if item not in self._constants:
-                    raise ValueError(f"Unknown identifier '{item}'")
-                val = self._constants[item]
+                if item in self._constants:
+                    val = self._constants[item]
+                    if isinstance(val, (int, float, bool, str)):
+                        expr_items.append(val)
+                    else:
+                        expr_items.append(val)
+                        unresolved = True
+                else:
+                    expr_items.append(item)
+                    unresolved = True
             else:
-                val = item
-            if idx == 0:
-                total = val
-            else:
+                expr_items.append(item)
+
+        if not unresolved:
+            total = expr_items[0]
+            for val in expr_items[1:]:
                 if not isinstance(total, (int, float)) or not isinstance(
                     val, (int, float)
                 ):
                     raise ValueError("Addition only allowed on numeric constants")
                 total += val
-        return total
+            return total
+        return expr_items
 
     def const_value(self, items):
         (value,) = items
@@ -491,6 +493,77 @@ class _Transformer(Transformer):
         definitions = [item for item in items[1:] if item is not None]
         return Module(name=name, definitions=definitions)
 
+    def _eval_expr(self, expr: Any, seen: Optional[set[str]] = None) -> Any:
+        if seen is None:
+            seen = set()
+        if isinstance(expr, list):
+            total = None
+            for item in expr:
+                val = self._eval_expr(item, seen)
+                if total is None:
+                    total = val
+                else:
+                    if not isinstance(total, (int, float)) or not isinstance(
+                        val, (int, float)
+                    ):
+                        raise ValueError(
+                            "Addition only allowed on numeric constants"
+                        )
+                    total += val
+            return total
+        if isinstance(expr, str):
+            if expr not in self._constants:
+                raise ValueError(f"Unknown identifier '{expr}'")
+            if expr in seen:
+                raise ValueError(f"Circular constant reference '{expr}'")
+            seen.add(expr)
+            val = self._eval_expr(self._constants[expr], seen)
+            seen.remove(expr)
+            return val
+        return expr
+
+    def resolve_constants(
+        self, definitions: List[Struct | Module | Constant | Enum | Typedef | Union]
+    ) -> None:
+        def resolve_defs(defs: List[Struct | Module | Constant | Enum | Typedef | Union]):
+            for d in defs:
+                if isinstance(d, Constant):
+                    d.value = self._eval_expr(d.value)
+                    self._constants[d.name] = d.value
+                elif isinstance(d, Struct):
+                    for f in d.fields:
+                        if f.sequence_bound is not None and not isinstance(
+                            f.sequence_bound, int
+                        ):
+                            f.sequence_bound = int(self._eval_expr(f.sequence_bound))
+                elif isinstance(d, Typedef):
+                    if d.sequence_bound is not None and not isinstance(
+                        d.sequence_bound, int
+                    ):
+                        d.sequence_bound = int(self._eval_expr(d.sequence_bound))
+                elif isinstance(d, Union):
+                    for case in d.cases:
+                        if case.field.sequence_bound is not None and not isinstance(
+                            case.field.sequence_bound, int
+                        ):
+                            case.field.sequence_bound = int(
+                                self._eval_expr(case.field.sequence_bound)
+                            )
+                        predicates = []
+                        for p in case.predicates:
+                            predicates.append(self._eval_expr(p))
+                        case.predicates = predicates
+                    if d.default and d.default.sequence_bound is not None and not isinstance(
+                        d.default.sequence_bound, int
+                    ):
+                        d.default.sequence_bound = int(
+                            self._eval_expr(d.default.sequence_bound)
+                        )
+                elif isinstance(d, Module):
+                    resolve_defs(d.definitions)
+
+        resolve_defs(definitions)
+
     def resolve_types(
         self, definitions: List[Struct | Module | Constant | Enum | Typedef | Union]
     ):
@@ -575,5 +648,6 @@ def parse_idl(source: str) -> List[Struct | Module | Constant | Enum | Typedef |
     tree = parser.parse(source)
     transformer = _Transformer()
     result = transformer.transform(tree)
+    transformer.resolve_constants(result)
     transformer.resolve_types(result)
     return result

--- a/mcap_ros2idl_support/omgidl_parser/parse.py
+++ b/mcap_ros2idl_support/omgidl_parser/parse.py
@@ -376,25 +376,19 @@ class _Transformer(Transformer):
         unresolved = False
         for item in items:
             if isinstance(item, str):
-                if item in self._constants:
-                    val = self._constants[item]
-                    if isinstance(val, (int, float, bool, str)):
-                        expr_items.append(val)
-                    else:
-                        expr_items.append(val)
-                        unresolved = True
-                else:
-                    expr_items.append(item)
+                val = self._constants.get(item, item)
+                if val is item:
                     unresolved = True
+                elif not isinstance(val, (int, float, bool, str)):
+                    unresolved = True
+                expr_items.append(val)
             else:
                 expr_items.append(item)
 
         if not unresolved:
             total = expr_items[0]
             for val in expr_items[1:]:
-                if not isinstance(total, (int, float)) or not isinstance(
-                    val, (int, float)
-                ):
+                if not isinstance(total, (int, float)) or not isinstance(val, (int, float)):
                     raise ValueError("Addition only allowed on numeric constants")
                 total += val
             return total
@@ -522,6 +516,11 @@ class _Transformer(Transformer):
             return val
         return expr
 
+    def _resolve_sequence_bound(self, bound: Any) -> Any:
+        if bound is not None and not isinstance(bound, int):
+            return int(self._eval_expr(bound))
+        return bound
+
     def resolve_constants(
         self, definitions: List[Struct | Module | Constant | Enum | Typedef | Union]
     ) -> None:
@@ -532,32 +531,22 @@ class _Transformer(Transformer):
                     self._constants[d.name] = d.value
                 elif isinstance(d, Struct):
                     for f in d.fields:
-                        if f.sequence_bound is not None and not isinstance(
-                            f.sequence_bound, int
-                        ):
-                            f.sequence_bound = int(self._eval_expr(f.sequence_bound))
+                        f.sequence_bound = self._resolve_sequence_bound(
+                            f.sequence_bound
+                        )
                 elif isinstance(d, Typedef):
-                    if d.sequence_bound is not None and not isinstance(
-                        d.sequence_bound, int
-                    ):
-                        d.sequence_bound = int(self._eval_expr(d.sequence_bound))
+                    d.sequence_bound = self._resolve_sequence_bound(
+                        d.sequence_bound
+                    )
                 elif isinstance(d, Union):
                     for case in d.cases:
-                        if case.field.sequence_bound is not None and not isinstance(
-                            case.field.sequence_bound, int
-                        ):
-                            case.field.sequence_bound = int(
-                                self._eval_expr(case.field.sequence_bound)
-                            )
-                        predicates = []
-                        for p in case.predicates:
-                            predicates.append(self._eval_expr(p))
-                        case.predicates = predicates
-                    if d.default and d.default.sequence_bound is not None and not isinstance(
-                        d.default.sequence_bound, int
-                    ):
-                        d.default.sequence_bound = int(
-                            self._eval_expr(d.default.sequence_bound)
+                        case.field.sequence_bound = self._resolve_sequence_bound(
+                            case.field.sequence_bound
+                        )
+                        case.predicates = [self._eval_expr(p) for p in case.predicates]
+                    if d.default:
+                        d.default.sequence_bound = self._resolve_sequence_bound(
+                            d.default.sequence_bound
                         )
                 elif isinstance(d, Module):
                     resolve_defs(d.definitions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcap-ros2idl-support"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Python library to read and parse ROS 2 MCAP bag files without a ROS 2 runtime."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/omgidl/test_deferred_constants.py
+++ b/tests/omgidl/test_deferred_constants.py
@@ -1,0 +1,31 @@
+import pytest
+
+from mcap_ros2idl_support.omgidl_parser.parse import parse_idl, Constant, Struct
+
+
+def test_forward_constant_reference() -> None:
+    source = """
+    const long A = B + 1;
+    const long B = 2;
+    """
+    definitions = parse_idl(source)
+    consts = {d.name: d for d in definitions if isinstance(d, Constant)}
+    assert consts["A"].value == 3
+    assert consts["B"].value == 2
+
+
+def test_forward_sequence_bound() -> None:
+    source = """
+    struct Foo { sequence<long, SIZE> data; };
+    const long SIZE = 5;
+    """
+    definitions = parse_idl(source)
+    struct = next(d for d in definitions if isinstance(d, Struct))
+    field = struct.fields[0]
+    assert field.sequence_bound == 5
+
+
+def test_unknown_identifier_raises() -> None:
+    source = "const long A = B + 1;"
+    with pytest.raises(ValueError):
+        parse_idl(source)

--- a/tests/omgidl/test_deferred_constants.py
+++ b/tests/omgidl/test_deferred_constants.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mcap_ros2idl_support.omgidl_parser.parse import parse_idl, Constant, Struct
+from mcap_ros2idl_support.omgidl_parser.parse import Constant, Struct, parse_idl
 
 
 def test_forward_constant_reference() -> None:


### PR DESCRIPTION
## Summary
- Defer evaluation of constant expressions and sequence bounds
- Add post-parse resolution pass to compute deferred expressions
- Test constant and sequence-bound resolution with forward references

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b9173a04788328823bc716f5190a99