### PR TITLE
Dskkato/add_encorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,43 @@ Use the ``--enum-as-string`` flag to return enumeration values as strings:
 python examples/cli.py --mcap-file sample.mcap --enum-as-string
 ```
 
+### Encoding example
+
+You can create CDR payloads for MCAP writing by combining
+`Ros2EncodeFactory` with the `mcap` writer API:
+
+```python
+from pathlib import Path
+from time import time_ns
+
+from mcap.writer import Writer
+from mcap_ros2idl_support import Ros2EncodeFactory
+
+schema_data = Path("example.idl").read_bytes()
+
+factory = Ros2EncodeFactory()
+writer = Writer("output.mcap")
+writer.start()
+schema_id = writer.register_schema(
+    name="example/msg/Sample",
+    encoding="ros2idl",
+    data=schema_data,
+)
+factory.register_schema(schema_id, encoding="ros2idl", data=schema_data)
+channel_id = writer.register_channel(
+    topic="/sample",
+    message_encoding="cdr",
+    schema_id=schema_id,
+)
+payload = factory.encode(schema_id, {"data": 42})
+now = time_ns()
+writer.add_message(channel_id, log_time=now, publish_time=now, data=payload)
+writer.finish()
+```
+
+The `examples/write_cdr_mcap.py` script wraps this flow so you can supply
+schema files and JSON messages directly from the command line.
+
 ## Development
 
 1. Create and activate a virtual environment:

--- a/examples/write_cdr_mcap.py
+++ b/examples/write_cdr_mcap.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Encode ROS 2 messages into MCAP using Ros2EncodeFactory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from time import time_ns
+from typing import Any, Iterable, List
+
+from mcap.writer import Writer
+
+from mcap_ros2idl_support import Ros2EncodeFactory
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Encode JSON ROS 2 messages as CDR and store them in an MCAP file."
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output MCAP file path.",
+    )
+    parser.add_argument(
+        "--topic",
+        required=True,
+        help="Topic name to record messages under.",
+    )
+    parser.add_argument(
+        "--schema-file",
+        required=True,
+        help="Path to a ros2idl or ros2msg schema definition.",
+    )
+    parser.add_argument(
+        "--schema-name",
+        required=True,
+        help="Schema name stored in the MCAP file.",
+    )
+    parser.add_argument(
+        "--schema-encoding",
+        choices=("ros2idl", "ros2msg"),
+        default="ros2idl",
+        help="Schema encoding, matching the contents of --schema-file.",
+    )
+    parser.add_argument(
+        "--message-file",
+        action="append",
+        default=[],
+        help="Path to a JSON file containing a message object or array of objects.",
+    )
+    parser.add_argument(
+        "--message",
+        action="append",
+        default=[],
+        help="Inline JSON message. Can be provided multiple times.",
+    )
+    parser.add_argument(
+        "--message-encoding",
+        default="cdr",
+        help="Value recorded as Channel.message_encoding (default: cdr).",
+    )
+    parser.add_argument(
+        "--log-time",
+        type=int,
+        default=None,
+        help="Override log_time (nanoseconds). Defaults to current time per message.",
+    )
+    parser.add_argument(
+        "--publish-time",
+        type=int,
+        default=None,
+        help="Override publish_time (nanoseconds). Defaults to log_time per message.",
+    )
+    return parser.parse_args()
+
+
+def _load_messages(paths: Iterable[str], literals: Iterable[str]) -> List[Any]:
+    messages: List[Any] = []
+
+    for literal in literals:
+        messages.append(json.loads(literal))
+
+    for path in paths:
+        data = json.loads(Path(path).read_text())
+        if isinstance(data, list):
+            messages.extend(data)
+        else:
+            messages.append(data)
+
+    return messages
+
+
+def main() -> None:
+    args = _parse_args()
+    messages = _load_messages(args.message_file, args.message)
+    if not messages:
+        raise SystemExit("No messages provided. Use --message or --message-file.")
+
+    schema_bytes = Path(args.schema_file).read_bytes()
+
+    factory = Ros2EncodeFactory()
+    writer = Writer(args.output)
+    writer.start()
+
+    schema_id = writer.register_schema(
+        name=args.schema_name,
+        encoding=args.schema_encoding,
+        data=schema_bytes,
+    )
+    factory.register_schema(
+        schema_id,
+        encoding=args.schema_encoding,
+        data=schema_bytes,
+    )
+    channel_id = writer.register_channel(
+        topic=args.topic,
+        message_encoding=args.message_encoding,
+        schema_id=schema_id,
+    )
+
+    for message in messages:
+        log_time = args.log_time if args.log_time is not None else time_ns()
+        publish_time = args.publish_time if args.publish_time is not None else log_time
+        payload = factory.encode(schema_id, message)
+        writer.add_message(
+            channel_id=channel_id,
+            log_time=log_time,
+            publish_time=publish_time,
+            data=payload,
+        )
+    writer.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/mcap_ros2idl_support/__init__.py
+++ b/mcap_ros2idl_support/__init__.py
@@ -6,5 +6,11 @@ from mcap_ros2idl_support.rosmsg2_serialization import (
 )
 
 from .decode_factory import Ros2DecodeFactory
+from .encode_factory import Ros2EncodeFactory
 
-__all__ = ["MessageReader", "MessageReaderOptions", "Ros2DecodeFactory"]
+__all__ = [
+    "MessageReader",
+    "MessageReaderOptions",
+    "Ros2DecodeFactory",
+    "Ros2EncodeFactory",
+]

--- a/mcap_ros2idl_support/encode_factory.py
+++ b/mcap_ros2idl_support/encode_factory.py
@@ -1,0 +1,118 @@
+"""Factory for building CDR encoders from ROS 2 schemas."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Tuple
+
+from mcap.records import Schema
+
+from mcap_ros2idl_support.ros2idl_parser import parse_ros2idl
+from mcap_ros2idl_support.rosmsg import parse as parse_ros2msg
+from mcap_ros2idl_support.rosmsg2_serialization import MessageWriter
+
+
+class Ros2EncodeFactory:
+    """Create :class:`MessageWriter` instances for ROS 2 schemas.
+
+    This mirrors :class:`Ros2DecodeFactory` but works in the opposite
+    direction: it parses ros2idl/ros2msg schemas and provides helpers to
+    encode Python dictionaries into CDR byte strings ready to hand to
+    :class:`mcap.writer.Writer.add_message`.
+    """
+
+    def __init__(self) -> None:
+        self._writers_by_schema_id: Dict[int, MessageWriter] = {}
+        self._writers_by_blob: Dict[Tuple[str, bytes], MessageWriter] = {}
+
+    # ------------------------------------------------------------------
+    # Schema registration helpers
+    # ------------------------------------------------------------------
+    def register_schema(self, schema_id: int, *, encoding: str, data: bytes | str) -> None:
+        """Register ``schema_id`` for subsequent :meth:`encode` calls."""
+
+        self._writers_by_schema_id[schema_id] = self._writer_from_blob(encoding, data)
+
+    # ------------------------------------------------------------------
+    # Encoding APIs using registered schemas
+    # ------------------------------------------------------------------
+    def encode(self, schema_id: int, message: Any) -> bytes:
+        """Encode ``message`` using a schema registered via :meth:`register_schema`."""
+
+        writer = self._writers_by_schema_id.get(schema_id)
+        if writer is None:
+            raise KeyError(f"Schema ID {schema_id} has not been registered")
+        return writer.write_message(message)
+
+    def calculate_size(self, schema_id: int, message: Any) -> int:
+        """Return the serialized size of ``message`` for ``schema_id``."""
+
+        writer = self._writers_by_schema_id.get(schema_id)
+        if writer is None:
+            raise KeyError(f"Schema ID {schema_id} has not been registered")
+        return writer.calculate_byte_size(message)
+
+    # ------------------------------------------------------------------
+    # APIs that accept :class:`mcap.records.Schema` directly
+    # ------------------------------------------------------------------
+    def writer_for_schema(self, schema: Schema) -> MessageWriter:
+        """Return a :class:`MessageWriter` for ``schema``."""
+
+        writer = self._writers_by_schema_id.get(schema.id)
+        if writer is not None:
+            return writer
+        writer = self._writer_from_blob(schema.encoding, schema.data)
+        self._writers_by_schema_id[schema.id] = writer
+        return writer
+
+    def encoder_for_schema(self, schema: Schema) -> Callable[[Any], bytes]:
+        """Return a callable that encodes messages for ``schema``."""
+
+        writer = self.writer_for_schema(schema)
+
+        def encode(message: Any) -> bytes:
+            return writer.write_message(message)
+
+        return encode
+
+    def encode_with_schema(self, schema: Schema, message: Any) -> bytes:
+        """Encode ``message`` directly from ``schema``."""
+
+        return self.writer_for_schema(schema).write_message(message)
+
+    def calculate_size_with_schema(self, schema: Schema, message: Any) -> int:
+        """Return the serialized size of ``message`` using ``schema``."""
+
+        return self.writer_for_schema(schema).calculate_byte_size(message)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _writer_from_blob(self, encoding: str, data: bytes | bytearray | str) -> MessageWriter:
+        schema_bytes = self._ensure_bytes(data)
+        key = (encoding, schema_bytes)
+        writer = self._writers_by_blob.get(key)
+        if writer is None:
+            writer = self._build_writer(encoding, schema_bytes)
+            self._writers_by_blob[key] = writer
+        return writer
+
+    def _build_writer(self, encoding: str, data: bytes) -> MessageWriter:
+        schema_text = data.decode("utf-8")
+        if encoding == "ros2idl":
+            definitions = parse_ros2idl(schema_text)
+        elif encoding == "ros2msg":
+            definitions = parse_ros2msg(schema_text)
+        else:
+            raise ValueError(f"Unknown schema encoding: {encoding}")
+        return MessageWriter(definitions)
+
+    @staticmethod
+    def _ensure_bytes(data: bytes | bytearray | str) -> bytes:
+        if isinstance(data, bytes):
+            return data
+        if isinstance(data, bytearray):
+            return bytes(data)
+        return data.encode("utf-8")
+
+
+__all__ = ["Ros2EncodeFactory"]

--- a/mcap_ros2idl_support/encode_factory.py
+++ b/mcap_ros2idl_support/encode_factory.py
@@ -27,7 +27,9 @@ class Ros2EncodeFactory:
     # ------------------------------------------------------------------
     # Schema registration helpers
     # ------------------------------------------------------------------
-    def register_schema(self, schema_id: int, *, encoding: str, data: bytes | str) -> None:
+    def register_schema(
+        self, schema_id: int, *, encoding: str, data: bytes | str
+    ) -> None:
         """Register ``schema_id`` for subsequent :meth:`encode` calls."""
 
         self._writers_by_schema_id[schema_id] = self._writer_from_blob(encoding, data)
@@ -87,7 +89,9 @@ class Ros2EncodeFactory:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-    def _writer_from_blob(self, encoding: str, data: bytes | bytearray | str) -> MessageWriter:
+    def _writer_from_blob(
+        self, encoding: str, data: bytes | bytearray | str
+    ) -> MessageWriter:
         schema_bytes = self._ensure_bytes(data)
         key = (encoding, schema_bytes)
         writer = self._writers_by_blob.get(key)

--- a/mcap_ros2idl_support/rosmsg2_serialization/message_writer.py
+++ b/mcap_ros2idl_support/rosmsg2_serialization/message_writer.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, List, Mapping, Sequence
 
 from mcap_ros2idl_support.cdr import CdrWriter
 from mcap_ros2idl_support.message_definition import (
+    AggregatedKind,
     DefaultValue,
     MessageDefinition,
     MessageDefinitionField,
@@ -34,97 +35,189 @@ PRIMITIVE_SIZES: Dict[str, int] = {
 
 
 class MessageWriter:
-    _root_definition: List[MessageDefinitionField]
-    _definitions: Mapping[str, List[MessageDefinitionField]]
+    _root_definition: MessageDefinition
+    _definitions: Mapping[str, MessageDefinition]
 
     def __init__(self, definitions: Sequence[MessageDefinition]) -> None:
         root_definition = next(
-            (d for d in definitions if not _is_constant_module(d)), None
+            (
+                d
+                for d in definitions
+                if d.aggregatedKind == AggregatedKind.STRUCT
+                and not _is_constant_module(d)
+            ),
+            None,
         )
         if root_definition is None:
+            root_definition = next(
+                (d for d in definitions if not _is_constant_module(d)), None
+            )
+        if root_definition is None:
             raise ValueError("MessageReader initialized with no root MessageDefinition")
-        self._root_definition = list(root_definition.definitions)
-        self._definitions = {d.name or "": list(d.definitions) for d in definitions}
+        self._root_definition = root_definition
+        self._definitions = {d.name or "": d for d in definitions}
+
+        enum_name_to_value: Dict[str, Dict[str, int]] = {}
+        enum_value_to_name: Dict[str, Dict[int, str]] = {}
+        for d in definitions:
+            if not _is_constant_module(d):
+                continue
+            name = d.name or ""
+            name_map: Dict[str, int] = {}
+            value_map: Dict[int, str] = {}
+            for field in d.definitions:
+                if isinstance(field.value, int):
+                    value = int(field.value)
+                    name_map[field.name] = value
+                    value_map[value] = field.name
+            if name_map:
+                enum_name_to_value[name] = name_map
+                enum_value_to_name[name] = value_map
+
+        self._enum_name_to_value = enum_name_to_value
+        self._union_enum_name_to_value: Dict[str, Dict[str, int]] = {}
+        for d in definitions:
+            if d.aggregatedKind != AggregatedKind.UNION:
+                continue
+            case_values: set[int] = set()
+            for case in d.cases:
+                preds = case.predicates or []
+                case_values.update(int(p) for p in preds)
+            prefix = (d.name or "").rsplit("/", 1)[0]
+            mapping_name = None
+            for enum_name, values in enum_value_to_name.items():
+                if prefix and not enum_name.startswith(prefix):
+                    continue
+                if case_values.issubset(values.keys()):
+                    mapping_name = enum_name
+                    break
+            if mapping_name is not None:
+                self._union_enum_name_to_value[d.name or ""] = enum_name_to_value[
+                    mapping_name
+                ]
 
     def calculate_byte_size(self, message: Any) -> int:
-        return self._byte_size(self._root_definition, message, 4)
+        return self._byte_size_definition(self._root_definition, message, 4)
 
     def write_message(self, message: Any, output: bytearray | None = None) -> bytes:
         writer = CdrWriter(
             buffer=output,
             size=None if output is not None else self.calculate_byte_size(message),
         )
-        self._write(self._root_definition, message, writer)
+        self._write_definition(self._root_definition, message, writer)
         return writer.data
 
-    def _byte_size(
-        self, definition: Sequence[MessageDefinitionField], message: Any, offset: int
+    def _byte_size_definition(
+        self, definition: MessageDefinition, message: Any, offset: int
+    ) -> int:
+        if definition.aggregatedKind == AggregatedKind.UNION:
+            return self._byte_size_union(definition, message, offset)
+        if definition.aggregatedKind != AggregatedKind.STRUCT:
+            raise ValueError(
+                f"Cannot serialize message definition of kind {definition.aggregatedKind}"
+            )
+        return self._byte_size_struct(definition, message, offset)
+
+    def _byte_size_struct(
+        self, definition: MessageDefinition, message: Any, offset: int
     ) -> int:
         message_obj = message if isinstance(message, dict) else {}
         new_offset = offset
 
-        if not message_definition_has_data_fields(definition):
+        if not message_definition_has_data_fields(definition.definitions):
             return offset + self._get_primitive_size("uint8")
 
-        for field in definition:
+        for field in definition.definitions:
             if field.isConstant is True:
                 continue
             nested_message = (
                 message_obj.get(field.name) if isinstance(message_obj, dict) else None
             )
-            if field.isArray is True:
-                array_length = field.arrayLength or _field_length(nested_message)
-                data_is_array = isinstance(nested_message, (list, tuple))
-                data_array = list(nested_message) if data_is_array else []
-                if field.arrayLength is None:
-                    new_offset += _padding(new_offset, 4)
-                    new_offset += 4
-                if field.isComplex is True:
-                    nested_definition = self._get_definition(field.type)
-                    for i in range(array_length):
-                        entry = data_array[i] if i < len(data_array) else {}
-                        new_offset = self._byte_size(
-                            nested_definition, entry, new_offset
-                        )
-                elif field.type == "string":
-                    for i in range(array_length):
-                        entry = data_array[i] if i < len(data_array) else ""
-                        new_offset += _padding(new_offset, 4)
-                        new_offset += 4 + len(entry) + 1
-                else:
-                    entry_size = self._get_primitive_size(field.type)
-                    alignment = 4 if field.type in {"time", "duration"} else entry_size
-                    new_offset += _padding(new_offset, alignment)
-                    new_offset += entry_size * array_length
-            else:
-                if field.isComplex is True:
-                    nested_definition = self._get_definition(field.type)
-                    entry = nested_message if isinstance(nested_message, dict) else {}
-                    new_offset = self._byte_size(nested_definition, entry, new_offset)
-                elif field.type == "string":
-                    entry = nested_message if isinstance(nested_message, str) else ""
-                    new_offset += _padding(new_offset, 4)
-                    new_offset += 4 + len(entry) + 1
-                else:
-                    entry_size = self._get_primitive_size(field.type)
-                    alignment = 4 if field.type in {"time", "duration"} else entry_size
-                    new_offset += _padding(new_offset, alignment)
-                    new_offset += entry_size
+            new_offset = self._byte_size_field(field, nested_message, new_offset)
         return new_offset
 
-    def _write(
-        self,
-        definition: Sequence[MessageDefinitionField],
-        message: Any,
-        writer: CdrWriter,
+    def _byte_size_union(
+        self, definition: MessageDefinition, message: Any, offset: int
+    ) -> int:
+        message_obj = message if isinstance(message, dict) else {}
+        switch_type = definition.switchType or ""
+        discr = self._resolve_union_discriminator(definition, message_obj)
+        discr = self._coerce_union_discriminator(discr, switch_type)
+        entry_size = self._get_primitive_size(switch_type or "uint32")
+        alignment = 4 if switch_type in {"time", "duration"} else entry_size
+        new_offset = offset + _padding(offset, alignment) + entry_size
+        field = _union_case_field(definition, discr)
+        if field is None:
+            raise ValueError(f"No union field matches discriminant {discr}")
+        nested_message = message_obj.get(field.name)
+        return self._byte_size_field(field, nested_message, new_offset)
+
+    def _byte_size_field(
+        self, field: MessageDefinitionField, nested_message: Any, offset: int
+    ) -> int:
+        new_offset = offset
+        if field.isArray is True:
+            array_length = field.arrayLength or _field_length(nested_message)
+            data_is_array = isinstance(nested_message, (list, tuple))
+            data_array = list(nested_message) if data_is_array else []
+            if field.arrayLength is None:
+                new_offset += _padding(new_offset, 4)
+                new_offset += 4
+            if field.isComplex is True:
+                nested_definition = self._get_definition(field.type)
+                for i in range(array_length):
+                    entry = data_array[i] if i < len(data_array) else {}
+                    new_offset = self._byte_size_definition(
+                        nested_definition, entry, new_offset
+                    )
+            elif field.type == "string":
+                for i in range(array_length):
+                    entry = data_array[i] if i < len(data_array) else ""
+                    new_offset += _padding(new_offset, 4)
+                    new_offset += 4 + len(entry) + 1
+            else:
+                entry_size = self._get_primitive_size(field.type)
+                alignment = 4 if field.type in {"time", "duration"} else entry_size
+                new_offset += _padding(new_offset, alignment)
+                new_offset += entry_size * array_length
+            return new_offset
+        if field.isComplex is True:
+            nested_definition = self._get_definition(field.type)
+            entry = nested_message if isinstance(nested_message, dict) else {}
+            return self._byte_size_definition(nested_definition, entry, new_offset)
+        if field.type == "string":
+            entry = nested_message if isinstance(nested_message, str) else ""
+            new_offset += _padding(new_offset, 4)
+            new_offset += 4 + len(entry) + 1
+            return new_offset
+        entry_size = self._get_primitive_size(field.type)
+        alignment = 4 if field.type in {"time", "duration"} else entry_size
+        new_offset += _padding(new_offset, alignment)
+        new_offset += entry_size
+        return new_offset
+
+    def _write_definition(
+        self, definition: MessageDefinition, message: Any, writer: CdrWriter
+    ) -> None:
+        if definition.aggregatedKind == AggregatedKind.UNION:
+            self._write_union(definition, message, writer)
+            return
+        if definition.aggregatedKind != AggregatedKind.STRUCT:
+            raise ValueError(
+                f"Cannot serialize message definition of kind {definition.aggregatedKind}"
+            )
+        self._write_struct(definition, message, writer)
+
+    def _write_struct(
+        self, definition: MessageDefinition, message: Any, writer: CdrWriter
     ) -> None:
         message_obj = message if isinstance(message, dict) else {}
 
-        if not message_definition_has_data_fields(definition):
+        if not message_definition_has_data_fields(definition.definitions):
             _uint8(0, 0, writer)
             return
 
-        for field in definition:
+        for field in definition.definitions:
             if field.isConstant is True:
                 continue
 
@@ -132,43 +225,133 @@ class MessageWriter:
                 message_obj.get(field.name) if isinstance(message_obj, dict) else None
             )
 
-            if field.isArray is True:
-                array_length = field.arrayLength or _field_length(nested_message)
-                data_is_array = isinstance(nested_message, (list, tuple))
-                data_array = list(nested_message) if data_is_array else []
-                if field.arrayLength is None:
-                    writer.sequenceLength(array_length)
-                if field.arrayLength is not None and nested_message is not None:
-                    given_length = _field_length(nested_message)
-                    if given_length != field.arrayLength:
-                        raise ValueError(
-                            "Expected {exp} items for fixed-length array field {name} "
-                            "but received {got}".format(
-                                exp=field.arrayLength,
-                                name=field.name,
-                                got=given_length,
-                            )
-                        )
-                if field.isComplex is True:
-                    nested_definition = self._get_definition(field.type)
-                    for i in range(array_length):
-                        entry = data_array[i] if i < len(data_array) else {}
-                        self._write(nested_definition, entry, writer)
-                else:
-                    array_writer = self._get_primitive_array_writer(field.type)
-                    array_writer(
-                        nested_message, field.defaultValue, writer, field.arrayLength
-                    )
-            else:
-                if field.isComplex is True:
-                    nested_definition = self._get_definition(field.type)
-                    entry = nested_message if nested_message is not None else {}
-                    self._write(nested_definition, entry, writer)
-                else:
-                    primitive_writer = self._get_primitive_writer(field.type)
-                    primitive_writer(nested_message, field.defaultValue, writer, None)
+            self._write_field(field, nested_message, writer)
 
-    def _get_definition(self, datatype: str) -> List[MessageDefinitionField]:
+    def _write_union(
+        self, definition: MessageDefinition, message: Any, writer: CdrWriter
+    ) -> None:
+        message_obj = message if isinstance(message, dict) else {}
+        discr = self._resolve_union_discriminator(definition, message_obj)
+        switch_type = definition.switchType or ""
+        discr = self._coerce_union_discriminator(discr, switch_type)
+        switch_writer = self._get_primitive_writer(switch_type)
+        switch_writer(discr, 0, writer, None)
+
+        field = _union_case_field(definition, discr)
+        if field is None:
+            raise ValueError(f"No union field matches discriminant {discr}")
+        nested_message = message_obj.get(field.name)
+        self._write_field(field, nested_message, writer)
+
+    def _write_field(
+        self, field: MessageDefinitionField, nested_message: Any, writer: CdrWriter
+    ) -> None:
+        if field.isArray is True:
+            array_length = field.arrayLength or _field_length(nested_message)
+            data_is_array = isinstance(nested_message, (list, tuple))
+            data_array = list(nested_message) if data_is_array else []
+            if field.arrayLength is None:
+                writer.sequenceLength(array_length)
+            if field.arrayLength is not None and nested_message is not None:
+                given_length = _field_length(nested_message)
+                if given_length != field.arrayLength:
+                    raise ValueError(
+                        "Expected {exp} items for fixed-length array field {name} "
+                        "but received {got}".format(
+                            exp=field.arrayLength,
+                            name=field.name,
+                            got=given_length,
+                        )
+                    )
+            if field.isComplex is True:
+                nested_definition = self._get_definition(field.type)
+                for i in range(array_length):
+                    entry = data_array[i] if i < len(data_array) else {}
+                    self._write_definition(nested_definition, entry, writer)
+            else:
+                write_value, write_default = self._resolve_enum_inputs(
+                    nested_message, field.defaultValue, field.enumType
+                )
+                array_writer = self._get_primitive_array_writer(field.type)
+                array_writer(write_value, write_default, writer, field.arrayLength)
+            return
+        if field.isComplex is True:
+            nested_definition = self._get_definition(field.type)
+            entry = nested_message if nested_message is not None else {}
+            self._write_definition(nested_definition, entry, writer)
+            return
+        write_value, write_default = self._resolve_enum_inputs(
+            nested_message, field.defaultValue, field.enumType
+        )
+        primitive_writer = self._get_primitive_writer(field.type)
+        primitive_writer(write_value, write_default, writer, None)
+
+    def _resolve_enum_inputs(
+        self, value: Any, default: DefaultValue, enum_type: str | None
+    ) -> tuple[Any, DefaultValue]:
+        if enum_type is None:
+            return value, default
+        mapping = self._enum_name_to_value.get(enum_type)
+        if mapping is None:
+            return value, default
+        return (
+            self._convert_enum_value(value, mapping),
+            self._convert_enum_value(default, mapping),
+        )
+
+    def _convert_enum_value(
+        self, value: Any, mapping: Dict[str, int]
+    ) -> Any:  # noqa: D401
+        if value is None:
+            return None
+        if isinstance(value, str):
+            if value not in mapping:
+                raise ValueError(f"Unknown enumerator '{value}'")
+            return mapping[value]
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            return [self._convert_enum_value(entry, mapping) for entry in value]
+        return value
+
+    def _resolve_union_discriminator(
+        self, definition: MessageDefinition, message_obj: Mapping[str, Any]
+    ) -> Any:
+        if "discriminator" not in message_obj:
+            raise ValueError(
+                f"Union {definition.name} requires a 'discriminator' entry"
+            )
+        discr = message_obj["discriminator"]
+        if isinstance(discr, str):
+            mapping = self._union_enum_name_to_value.get(definition.name or "")
+            if mapping is None or discr not in mapping:
+                raise ValueError(
+                    f"Unknown union discriminator '{discr}' for {definition.name}"
+                )
+            return mapping[discr]
+        return discr
+
+    def _coerce_union_discriminator(self, value: Any, switch_type: str) -> Any:
+        if switch_type in {
+            "int8",
+            "uint8",
+            "int16",
+            "uint16",
+            "int32",
+            "uint32",
+            "int64",
+            "uint64",
+            "char",
+            "byte",
+        }:
+            return int(value)
+        if switch_type in {"float32", "float64"}:
+            return float(value)
+        if switch_type == "bool":
+            return bool(value)
+        return value
+
+    def _get_definition(self, datatype: str) -> MessageDefinition:
         nested = self._definitions.get(datatype)
         if nested is None:
             raise ValueError(f"Unrecognized complex type {datatype}")
@@ -492,6 +675,15 @@ def _padding(offset: int, byte_width: int) -> int:
 
 def _is_constant_module(defn: MessageDefinition) -> bool:
     return len(defn.definitions) > 0 and all(f.isConstant for f in defn.definitions)
+
+
+def _union_case_field(
+    defn: MessageDefinition, discriminator: Any
+) -> MessageDefinitionField | None:
+    for case in defn.cases:
+        if case.predicates and discriminator in case.predicates:
+            return case.type
+    return defn.defaultCase
 
 
 __all__ = ["MessageWriter"]

--- a/mcap_ros2idl_support/rosmsg2_serialization/message_writer.py
+++ b/mcap_ros2idl_support/rosmsg2_serialization/message_writer.py
@@ -53,9 +53,7 @@ class MessageWriter:
                 (d for d in definitions if not _is_constant_module(d)), None
             )
         if root_definition is None:
-            raise ValueError(
-                "MessageWriter initialized with no root MessageDefinition"
-            )
+            raise ValueError("MessageWriter initialized with no root MessageDefinition")
         self._root_definition = root_definition
         self._definitions = {d.name or "": d for d in definitions}
 

--- a/mcap_ros2idl_support/rosmsg2_serialization/message_writer.py
+++ b/mcap_ros2idl_support/rosmsg2_serialization/message_writer.py
@@ -53,7 +53,9 @@ class MessageWriter:
                 (d for d in definitions if not _is_constant_module(d)), None
             )
         if root_definition is None:
-            raise ValueError("MessageReader initialized with no root MessageDefinition")
+            raise ValueError(
+                "MessageWriter initialized with no root MessageDefinition"
+            )
         self._root_definition = root_definition
         self._definitions = {d.name or "": d for d in definitions}
 

--- a/mcap_ros2idl_support/rosmsg2_serialization/message_writer.py
+++ b/mcap_ros2idl_support/rosmsg2_serialization/message_writer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Mapping, Sequence
+from typing import Any, Callable, Dict, Mapping, Sequence
 
 from mcap_ros2idl_support.cdr import CdrWriter
 from mcap_ros2idl_support.message_definition import (
@@ -114,7 +114,9 @@ class MessageWriter:
             return self._byte_size_union(definition, message, offset)
         if definition.aggregatedKind != AggregatedKind.STRUCT:
             raise ValueError(
-                f"Cannot serialize message definition of kind {definition.aggregatedKind}"
+                "Cannot serialize message definition of kind {}".format(
+                    definition.aggregatedKind
+                )
             )
         return self._byte_size_struct(definition, message, offset)
 
@@ -204,7 +206,9 @@ class MessageWriter:
             return
         if definition.aggregatedKind != AggregatedKind.STRUCT:
             raise ValueError(
-                f"Cannot serialize message definition of kind {definition.aggregatedKind}"
+                "Cannot serialize message definition of kind {}".format(
+                    definition.aggregatedKind
+                )
             )
         self._write_struct(definition, message, writer)
 

--- a/tests/test_encode_factory.py
+++ b/tests/test_encode_factory.py
@@ -195,7 +195,6 @@ def test_union_and_enum_encoding() -> None:
     expected = bytes.fromhex("00010000010000000600000068656c6c6f00000000000000")
     assert factory.encode_with_schema(schema, message) == expected
 
-
 def test_encode_decode_round_trip_union_and_enum() -> None:
     factory = Ros2EncodeFactory()
     idl = """module test {

--- a/tests/test_encode_factory.py
+++ b/tests/test_encode_factory.py
@@ -195,6 +195,7 @@ def test_union_and_enum_encoding() -> None:
     expected = bytes.fromhex("00010000010000000600000068656c6c6f00000000000000")
     assert factory.encode_with_schema(schema, message) == expected
 
+
 def test_encode_decode_round_trip_union_and_enum() -> None:
     factory = Ros2EncodeFactory()
     idl = """module test {

--- a/tests/test_encode_factory.py
+++ b/tests/test_encode_factory.py
@@ -4,6 +4,11 @@ import pytest
 from mcap.records import Schema
 
 from mcap_ros2idl_support.encode_factory import Ros2EncodeFactory
+from mcap_ros2idl_support.ros2idl_parser import parse_ros2idl
+from mcap_ros2idl_support.rosmsg2_serialization import (
+    MessageReader,
+    MessageReaderOptions,
+)
 
 
 def test_register_schema_and_encode() -> None:
@@ -50,3 +55,170 @@ def test_unknown_encoding_raises() -> None:
     schema = Schema(id=3, name="test", encoding="jsonschema", data=b"{}")
     with pytest.raises(ValueError):
         factory.encoder_for_schema(schema)
+
+
+def test_encode_nested_struct_and_arrays_ros2msg() -> None:
+    factory = Ros2EncodeFactory()
+    msg_def = """std_msgs/msg/Header header
+geometry_msgs/msg/Vector3[] points
+================================================================================
+MSG: std_msgs/msg/Header
+builtin_interfaces/msg/Time stamp
+string frame_id
+================================================================================
+MSG: builtin_interfaces/msg/Time
+int32 sec
+uint32 nanosec
+================================================================================
+MSG: geometry_msgs/msg/Vector3
+float64 x
+float64 y
+float64 z
+"""
+    schema = Schema(
+        id=9,
+        name="example/Nested",
+        encoding="ros2msg",
+        data=msg_def.encode("utf-8"),
+    )
+    message = {
+        "header": {
+            "stamp": {"sec": 10, "nanosec": 42},
+            "frame_id": "map",
+        },
+        "points": [
+            {"x": 1.5, "y": 2.5, "z": 3.5},
+            {"x": -1.25, "y": 0.0, "z": 10.0},
+        ],
+    }
+    expected = bytes.fromhex(
+        "000100000a0000002a000000040000006d6170000200000000000000000000000000f83f"
+        "00000000000004400000000000000c40000000000000f4bf00000000000000000000000000002440"
+    )
+    assert factory.encode_with_schema(schema, message) == expected
+    # Ensure the cached encoder path returns the same payload
+    encoder = factory.encoder_for_schema(schema)
+    assert encoder(message) == expected
+    assert factory.calculate_size_with_schema(schema, message) == len(expected)
+
+
+def test_encode_fixed_and_bounded_arrays_ros2idl() -> None:
+    factory = Ros2EncodeFactory()
+    idl = """module example {
+  module msg {
+    struct Complex {
+      Inner readings[2];
+      sequence<double,2> weights;
+    };
+    struct Inner {
+      long count;
+      boolean flag;
+    };
+  };
+};
+"""
+    schema = Schema(
+        id=11,
+        name="example/msg/Complex",
+        encoding="ros2idl",
+        data=idl.encode("utf-8"),
+    )
+    message = {
+        "readings": [
+            {"count": 5, "flag": True},
+            {"count": -2, "flag": False},
+        ],
+        "weights": [1.0, -3.5],
+    }
+    expected = bytes.fromhex(
+        "000100000500000001000000feffffff000000000200000000000000000000000000f03f"
+        "0000000000000cc0"
+    )
+    assert factory.encode_with_schema(schema, message) == expected
+    assert factory.calculate_size_with_schema(schema, message) == len(expected)
+
+
+def test_multiple_schema_ids_and_channels() -> None:
+    factory = Ros2EncodeFactory()
+    schema_ros2msg = "int32 data"
+    idl = """module example {
+  module msg {
+    struct Point {
+      double x;
+      double y;
+    };
+  };
+};
+"""
+    factory.register_schema(1, encoding="ros2msg", data=schema_ros2msg)
+    factory.register_schema(2, encoding="ros2idl", data=idl)
+
+    msg_a = {"data": 10}
+    msg_b = {"x": 1.0, "y": -2.5}
+
+    expected_a = b"\x00\x01\x00\x00" + struct.pack("<i", 10)
+    expected_b = b"\x00\x01\x00\x00" + struct.pack("<2d", 1.0, -2.5)
+
+    assert factory.encode(1, msg_a) == expected_a
+    assert factory.encode(2, msg_b) == expected_b
+
+    # Re-encode to ensure cached writers remain distinct
+    other_a = b"\x00\x01\x00\x00" + struct.pack("<i", -5)
+    assert factory.encode(1, {"data": -5}) == other_a
+
+
+def test_union_and_enum_encoding() -> None:
+    factory = Ros2EncodeFactory()
+    idl = """module test {
+  enum Switch { INT_CASE, TEXT_CASE };
+  union IntOrString switch(Switch) {
+    case INT_CASE: int32 num;
+    case TEXT_CASE: string text;
+  };
+  struct Wrapper {
+    IntOrString value;
+    test::Switch status;
+  };
+};
+"""
+    schema = Schema(
+        id=13,
+        name="test/Wrapper",
+        encoding="ros2idl",
+        data=idl.encode("utf-8"),
+    )
+    message = {
+        "value": {"discriminator": "TEXT_CASE", "text": "hello"},
+        "status": "INT_CASE",
+    }
+    expected = bytes.fromhex("00010000010000000600000068656c6c6f00000000000000")
+    assert factory.encode_with_schema(schema, message) == expected
+
+def test_encode_decode_round_trip_union_and_enum() -> None:
+    factory = Ros2EncodeFactory()
+    idl = """module test {
+  enum Switch { INT_CASE, TEXT_CASE };
+  union IntOrString switch(Switch) {
+    case INT_CASE: int32 num;
+    case TEXT_CASE: string text;
+  };
+  struct Wrapper {
+    IntOrString value;
+    test::Switch status;
+  };
+};
+"""
+    schema = Schema(
+        id=21,
+        name="test/Wrapper",
+        encoding="ros2idl",
+        data=idl.encode("utf-8"),
+    )
+    message = {
+        "value": {"discriminator": "TEXT_CASE", "text": "hello"},
+        "status": "INT_CASE",
+    }
+    encoded = factory.encode_with_schema(schema, message)
+    defs = parse_ros2idl(idl)
+    reader = MessageReader(defs, MessageReaderOptions(enumAsString=True))
+    assert reader.read_message(encoded) == message

--- a/tests/test_encode_factory.py
+++ b/tests/test_encode_factory.py
@@ -93,7 +93,8 @@ float64 z
     }
     expected = bytes.fromhex(
         "000100000a0000002a000000040000006d6170000200000000000000000000000000f83f"
-        "00000000000004400000000000000c40000000000000f4bf00000000000000000000000000002440"
+        "00000000000004400000000000000c40000000000000f4bf000000000000000000000000"
+        "00002440"
     )
     assert factory.encode_with_schema(schema, message) == expected
     # Ensure the cached encoder path returns the same payload
@@ -193,6 +194,7 @@ def test_union_and_enum_encoding() -> None:
     }
     expected = bytes.fromhex("00010000010000000600000068656c6c6f00000000000000")
     assert factory.encode_with_schema(schema, message) == expected
+
 
 def test_encode_decode_round_trip_union_and_enum() -> None:
     factory = Ros2EncodeFactory()

--- a/tests/test_encode_factory.py
+++ b/tests/test_encode_factory.py
@@ -1,0 +1,52 @@
+import struct
+
+import pytest
+from mcap.records import Schema
+
+from mcap_ros2idl_support.encode_factory import Ros2EncodeFactory
+
+
+def test_register_schema_and_encode() -> None:
+    factory = Ros2EncodeFactory()
+    schema_text = "int32 counter"
+    factory.register_schema(1, encoding="ros2msg", data=schema_text)
+
+    message = {"counter": 42}
+    encoded = factory.encode(1, message)
+    expected = b"\x00\x01\x00\x00" + struct.pack("<i", 42)
+    assert encoded == expected
+    assert factory.calculate_size(1, message) == len(expected)
+
+
+def test_encoder_for_schema_ros2idl() -> None:
+    factory = Ros2EncodeFactory()
+    idl = """module example {
+  module msg {
+    struct Sample {
+      long data;
+      int32 sequence_id;
+    };
+  };
+};
+"""
+    schema = Schema(
+        id=5,
+        name="example/msg/Sample",
+        encoding="ros2idl",
+        data=idl.encode("utf-8"),
+    )
+    encoder = factory.encoder_for_schema(schema)
+
+    message = {"data": 7}
+    encoded = encoder(message)
+    expected = b"\x00\x01\x00\x00" + struct.pack("<i", 7) + struct.pack("<i", 0)
+    assert encoded == expected
+    assert factory.calculate_size_with_schema(schema, message) == len(expected)
+    assert factory.encode_with_schema(schema, message) == expected
+
+
+def test_unknown_encoding_raises() -> None:
+    factory = Ros2EncodeFactory()
+    schema = Schema(id=3, name="test", encoding="jsonschema", data=b"{}")
+    with pytest.raises(ValueError):
+        factory.encoder_for_schema(schema)


### PR DESCRIPTION
## Pull request overview

This pull request adds encoding support to complement the existing decoding functionality in the mcap_ros2idl_support library. It introduces the `Ros2EncodeFactory` class that allows users to encode Python dictionaries into CDR-encoded byte streams suitable for writing to MCAP files, mirroring the existing `Ros2DecodeFactory` for decoding.

### Changes:
- Added `Ros2EncodeFactory` class for creating CDR encoders from ROS 2 schemas
- Extended `MessageWriter` to support union and enum types, including discriminator handling and enum string-to-value conversion
- Added comprehensive test coverage for the new encoding functionality including unions, enums, nested structs, and arrays
